### PR TITLE
Feature/test anon and scopes epic

### DIFF
--- a/biblib/app.py
+++ b/biblib/app.py
@@ -3,7 +3,7 @@ Application
 """
 
 from flask import Flask
-from views import UserView, LibraryView, PermissionView
+from views import UserView, LibraryView, DocumentView, PermissionView
 from flask.ext.restful import Api
 from flask.ext.discoverer import Discoverer
 from models import db
@@ -58,7 +58,11 @@ def create_app(config_type='PRODUCTION'):
 
     api.add_resource(LibraryView,
                      '/libraries/<string:library>',
-                     methods=['GET', 'POST', 'DELETE'])
+                     methods=['GET'])
+
+    api.add_resource(DocumentView,
+                     '/documents/<string:library>',
+                     methods=['POST', 'DELETE'],)
 
     api.add_resource(PermissionView,
                      '/permissions/<string:library>',
@@ -71,7 +75,7 @@ def create_app(config_type='PRODUCTION'):
     handler = setup_logging_handler(level='DEBUG')
     app.logger.addHandler(handler)
 
-    discoverer = Discoverer(app)
+    Discoverer(app)
     return app
 
 if __name__ == '__main__':

--- a/biblib/tests/functional_tests/test_anonymous_epic.py
+++ b/biblib/tests/functional_tests/test_anonymous_epic.py
@@ -1,0 +1,137 @@
+"""
+Functional test
+
+Anonymous Epic
+
+Storyboard is defined within the comments of the program itself
+"""
+
+__author__ = 'J. Elliott'
+__maintainer__ = 'J. Elliott'
+__copyright__ = 'ADS Copyright 2015'
+__version__ = '1.0'
+__email__ = 'ads@cfa.harvard.edu'
+__status__ = 'Production'
+__license__ = 'MIT'
+
+import sys
+import os
+
+PROJECT_HOME = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../'))
+sys.path.append(PROJECT_HOME)
+
+import app
+import json
+import unittest
+from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
+from models import db
+from flask.ext.testing import TestCase
+from flask import url_for
+from tests.stubdata.stub_data import StubDataLibrary, StubDataDocument, \
+    StubDataUser
+from tests.base import MockADSWSAPI
+
+
+class TestAnonymousEpic(TestCase):
+    """
+    Base class used to test the Big Share Admin Epic
+    """
+    def create_app(self):
+        """
+        Create the wsgi application for flask
+
+        :return: application instance
+        """
+        return app.create_app(config_type='TEST')
+
+    def setUp(self):
+        """
+        Set up the database for use
+
+        :return: no return
+        """
+        db.create_all()
+
+    def tearDown(self):
+        """
+        Remove/delete the database and the relevant connections
+!
+        :return: no return
+        """
+        db.session.remove()
+        db.drop_all()
+
+    def test_anonymous_epic(self):
+        """
+        Carries out the epic 'Anonymous', where a user tries to access a
+        private library and also a public library. The user also (artificial)
+        tries to access any other endpoints that do not have any scopes set
+
+        :return: no return
+        """
+
+        # Define two sets of stub data
+        # user: who makes a library (e.g., Dave the librarian)
+        # anon: someone using the BBB client
+        uid_anonymous = StubDataUser().get_user()
+        headers_anonymous = {USER_ID_KEYWORD: uid_anonymous}
+        email_anonymous = "mary@email.com"
+
+        library_dave, uid_dave = StubDataLibrary().make_stub()
+        headers_dave = {USER_ID_KEYWORD: uid_dave}
+        email_dave = "dave@email.com"
+
+        # Dave makes two libraries
+        # One private library
+        # One public library
+        url = url_for('userview')
+
+        library_dave['public'] = False
+        library_dave['name'] = 'Private'
+        response = self.client.post(
+            url,
+            data=json.dumps(library_dave),
+            headers=headers_dave
+        )
+        library_id_private = response.json['id']
+        self.assertEqual(response.status_code, 200, response)
+
+        library_dave['public'] = True
+        library_dave['name'] = 'Public'
+        response = self.client.post(
+            url,
+            data=json.dumps(library_dave),
+            headers=headers_dave
+        )
+        library_id_public = response.json['id']
+
+        # Anonymous user tries to access the private library. But cannot.
+        url = url_for('libraryview', library=library_id_private)
+        response = self.client.get(
+            url,
+            headers=headers_anonymous
+        )
+        self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
+        self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
+
+        # Anonymous user tries to access the public library. And can.
+        url = url_for('libraryview', library=library_id_public)
+        response = self.client.get(
+            url,
+            headers=headers_anonymous
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('documents', response.json)
+
+        number_of_scopeless = 0
+        response = self.client.get('/resources')
+        for end_point in response.json.keys():
+            if len(response.json[end_point]['scopes']) == 0:
+                number_of_scopeless += 1
+
+        self.assertEqual(1, number_of_scopeless)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/functional_tests/test_anonymous_epic.py
+++ b/biblib/tests/functional_tests/test_anonymous_epic.py
@@ -128,10 +128,13 @@ class TestAnonymousEpic(TestCase):
         number_of_scopeless = 0
         response = self.client.get('/resources')
         for end_point in response.json.keys():
+
             if len(response.json[end_point]['scopes']) == 0:
                 number_of_scopeless += 1
+                endpoint = end_point
 
         self.assertEqual(1, number_of_scopeless)
+        self.assertEqual('/libraries/<string:library>', endpoint)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/biblib/tests/functional_tests/test_big_share_admin_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_admin_epic.py
@@ -102,7 +102,7 @@ class TestDeletionEpic(TestCase):
         number_of_documents = 20
         for i in range(number_of_documents):
             # Add document
-            url = url_for('libraryview', library=library_id_dave)
+            url = url_for('documentview', library=library_id_dave)
             stub_document = StubDataDocument().make_stub(action='add')
 
             libraries_added.append(stub_document['bibcode'])
@@ -201,7 +201,7 @@ class TestDeletionEpic(TestCase):
 
         # The student removes a few bibcodes and keeps a list of the ones she
         # removed just in case
-        url = url_for('libraryview', library=library_id_dave)
+        url = url_for('documentview', library=library_id_dave)
 
         libraries_removed = []
         for i in range(number_of_documents/2):
@@ -234,6 +234,7 @@ class TestDeletionEpic(TestCase):
 
         # Dave asks Mary to re-add the ones she removed because they were
         # actually useful
+        url = url_for('documentview', library=library_id_dave)
         for bibcode in libraries_removed:
             # Add documents
 
@@ -293,7 +294,7 @@ class TestDeletionEpic(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # The student tries to add content
-        url = url_for('libraryview', library=library_id_dave)
+        url = url_for('documentview', library=library_id_dave)
         stub_document['bibcode'] = 'failure'
         response = self.client.post(
             url,

--- a/biblib/tests/functional_tests/test_big_share_editor_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_editor_epic.py
@@ -95,7 +95,7 @@ class TestDeletionEpic(TestCase):
         number_of_documents = 20
         for i in range(number_of_documents):
             # Add document
-            url = url_for('libraryview', library=library_id_dave)
+            url = url_for('documentview', library=library_id_dave)
             stub_document = StubDataDocument().make_stub(action='add')
 
             libraries_added.append(stub_document['bibcode'])
@@ -118,6 +118,7 @@ class TestDeletionEpic(TestCase):
         # Dave is too busy to do any work on the library and so asks his
         # librarian friend Mary to do it. Dave does not realise she cannot
         # add without permissions and Mary gets some error messages
+        url = url_for('documentview', library=library_id_dave)
         stub_document['bibcode'] = 'failure'
         response = self.client.post(
             url,
@@ -167,7 +168,7 @@ class TestDeletionEpic(TestCase):
 
         # Mary removes a few bibcodes and keeps a list of the ones she
         # removed just in case
-        url = url_for('libraryview', library=library_id_dave)
+        url = url_for('documentview', library=library_id_dave)
 
         libraries_removed = []
         for i in range(number_of_documents/2):
@@ -200,6 +201,7 @@ class TestDeletionEpic(TestCase):
 
         # Dave asks Mary to re-add the ones she removed because they were
         # actually useful
+        url = url_for('documentview', library=library_id_dave)
         for bibcode in libraries_removed:
             # Add documents
 
@@ -256,7 +258,7 @@ class TestDeletionEpic(TestCase):
         self.assertEqual(response.status_code, 200)
 
         # Mary tries to add content
-        url = url_for('libraryview', library=library_id_dave)
+        url = url_for('documentview', library=library_id_dave)
         stub_document['bibcode'] = 'failure'
         response = self.client.post(
             url,

--- a/biblib/tests/functional_tests/test_big_share_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_epic.py
@@ -106,7 +106,7 @@ class TestDeletionEpic(TestCase):
         number_of_documents = 20
         for i in range(number_of_documents):
             # Add document
-            url = url_for('libraryview', library=library_id_dave)
+            url = url_for('documentview', library=library_id_dave)
             stub_document = StubDataDocument().make_stub(action='add')
 
             response = self.client.post(

--- a/biblib/tests/functional_tests/test_deletion_epic.py
+++ b/biblib/tests/functional_tests/test_deletion_epic.py
@@ -124,7 +124,7 @@ class TestDeletionEpic(TestCase):
         library_id_2 = response.json['libraries'][1]['id']
 
         # Deletes the second library
-        url = url_for('libraryview', library=library_id_2)
+        url = url_for('documentview', library=library_id_2)
         response = self.client.delete(
             url,
             headers=headers
@@ -140,7 +140,7 @@ class TestDeletionEpic(TestCase):
         self.assertTrue(len(response.json['libraries']) == 1)
 
         # Deletes the first library
-        url = url_for('libraryview', library=library_id_1)
+        url = url_for('documentview', library=library_id_1)
         response = self.client.delete(
             url,
             headers=headers

--- a/biblib/tests/functional_tests/test_job_epic.py
+++ b/biblib/tests/functional_tests/test_job_epic.py
@@ -80,8 +80,9 @@ class TestJobEpic(TestCase):
         # that will come from the ADSWS
         headers = {USER_ID_KEYWORD: self.stub_uid}
 
-        # Make the library
+        # Make the library and make it public to be viewed by employers
         url = url_for('userview')
+        self.stub_library['public'] = True
         response = self.client.post(
             url,
             data=json.dumps(self.stub_library),
@@ -104,7 +105,7 @@ class TestJobEpic(TestCase):
 
         # Then she submits the document (in this case a bibcode) to add to the
         # library
-        url = url_for('libraryview', library=library_id)
+        url = url_for('documentview', library=library_id)
         self.stub_document['action'] = 'add'
         response = self.client.post(
             url,
@@ -113,9 +114,9 @@ class TestJobEpic(TestCase):
         )
         self.assertEqual(response.status_code, 200, response)
 
-        # Mary realises she added one that is not hers and goes back to her list
-        # and deletes it from her library.
-        url = url_for('libraryview', library=library_id)
+        # Mary realises she added one that is not hers and goes back to her
+        # list and deletes it from her library.
+        url = url_for('documentview', library=library_id)
         self.stub_document['action'] = 'remove'
         response = self.client.post(
             url,
@@ -124,17 +125,23 @@ class TestJobEpic(TestCase):
         )
         self.assertEqual(response.status_code, 200, response)
 
-        response = response = self.client.get(
+        url = url_for('libraryview', library=library_id)
+        response = self.client.get(
             url,
             headers=headers
         )
         self.assertTrue(len(response.json['documents']) == 0, response.json)
 
-        # Happy with her library, she copies the link to the library and e-mails
-        # it to the prospective employer.
+        # Happy with her library, she copies the link to the library and
+        # e-mails it to the prospective employer.
 
-        # She then checks the link herself as she is paranoid it may not work,
-        # but it works fine.
+        # She then asks a friend to check the link, and it works fine.
+        random_headers = {USER_ID_KEYWORD: self.stub_uid*2}
+        response = self.client.get(
+            url,
+            headers=random_headers
+        )
+        self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -125,9 +125,9 @@ class StubDataLibrary(object):
         stub_library = dict(
             name=jumble,
             description='My first library',
-            read=True,
-            write=True,
-            public=True
+            read=False,
+            write=False,
+            public=False
         )
 
         return stub_library

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -103,7 +103,7 @@ class TestWebservices(TestCase):
         :return: no return
         """
 
-        url = url_for('libraryview', library='test')
+        url = url_for('documentview', library='test')
         response = self.client.post(url)
 
         self.assertEqual(response.status_code, MISSING_USERNAME_ERROR['number'])
@@ -164,7 +164,7 @@ class TestWebservices(TestCase):
 
     def test_add_document_to_library(self):
         """
-        Test the /libraries/<> end point with POST to add a document
+        Test the /documents/<> end point with POST to add a document
 
         :return: no return
         """
@@ -189,7 +189,7 @@ class TestWebservices(TestCase):
 
         # Add to the library
         self.stub_document['action'] = 'add'
-        url = url_for('libraryview', library=library_id)
+        url = url_for('documentview', library=library_id)
 
         response = self.client.post(
             url,
@@ -198,6 +198,7 @@ class TestWebservices(TestCase):
         )
 
         # Check the library was created and documents exist
+        url = url_for('libraryview', library=library_id)
         response = self.client.get(
             url,
             data=json.dumps(payload),
@@ -232,7 +233,7 @@ class TestWebservices(TestCase):
 
         # Add to the library
         self.stub_document['action'] = 'add'
-        url = url_for('libraryview', library=library_id)
+        url = url_for('documentview', library=library_id)
 
         response = self.client.post(
             url,
@@ -244,7 +245,7 @@ class TestWebservices(TestCase):
 
         # Delete the document
         self.stub_document['action'] = 'remove'
-        url = url_for('libraryview', library=library_id)
+        url = url_for('documentview', library=library_id)
 
         response = self.client.post(
             url,
@@ -325,7 +326,7 @@ class TestWebservices(TestCase):
         library_id = response.json['id']
 
         # Delete the library
-        url = url_for('libraryview', user=self.stub_user_id, library=library_id)
+        url = url_for('documentview', user=self.stub_user_id, library=library_id)
         response = self.client.delete(
             url,
             headers=headers
@@ -357,7 +358,7 @@ class TestWebservices(TestCase):
 
         # Try to delete even though it does not exist, this should return
         # some errors from the server
-        url = url_for('libraryview', library=library_id)
+        url = url_for('documentview', library=library_id)
 
         response = self.client.delete(
             url,
@@ -754,7 +755,7 @@ class TestWebservices(TestCase):
         # See if a random user can edit content of the library
         # Add to the library
         self.stub_document['action'] = 'add'
-        url = url_for('libraryview', library=library_id)
+        url = url_for('documentview', library=library_id)
 
         response = self.client.post(
             url,


### PR DESCRIPTION
Addresses issue #7. The commit messages are self explanatory:

  * Anonymous users will be handled by the API, such that they can only access endpoints with no scope.
  * The GET endpoint for /libraries/<> was made scopeless.
  * As different methods cannot have their own scope, a separate endpoint was created /documents/<>, to allow the POST and DELETE methods that were originally a part of the libraries endpoint.
  * The tests were updated and split to encorporate this new endpoint, and view.
  * A minor check that the correct view is scopeless was added to the anonymous epic test.
  * Tests included that tests public libraries can be accessed by anonymous users.