### PR TITLE
Addresses and closes issue #26

### DIFF
--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -10,13 +10,50 @@ PROJECT_HOME = os.path.abspath(
 sys.path.append(PROJECT_HOME)
 
 import unittest
+import uuid
 from models import db, User, Library, Permissions
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
-from views import UserView, LibraryView, DocumentView, PermissionView
+from views import UserView, LibraryView, DocumentView, PermissionView, BaseView
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from utils import BackendIntegrityError, PermissionDeniedError
 from tests.base import TestCaseDatabase
+
+
+class TestBaseViews(TestCaseDatabase):
+    """
+    Class for testing helper functions that are not neccessarily related to a
+    single View and do not need special behaviour related to a view.
+    """
+
+    def test_slug_to_uuid(self):
+        """
+        Test the conversion of a base64 URL encoded string to a UUID behaves as
+        expected
+
+        :return:
+        """
+        input_slug = '878JECDeTX6hoI77gq1Y2Q'
+        expected_uuid = 'f3bf0910-20de-4d7e-a1a0-8efb82ad58d9'
+
+        output_uuid = BaseView().helper_slug_to_uuid(input_slug)
+
+        self.assertEqual(expected_uuid, output_uuid)
+
+    def test_uuid_to_slug(self):
+        """
+        Test the conversion of UUID to a base64 URL encoded string behaves as
+        expected
+
+        :return: no return
+        """
+        input_uuid = uuid.UUID('f3bf0910-20de-4d7e-a1a0-8efb82ad58d9')
+        expected_slug = '878JECDeTX6hoI77gq1Y2Q'
+
+        output_slug = BaseView().helper_uuid_to_slug(input_uuid)
+
+        self.assertEqual(expected_slug, output_slug)
+
 
 
 class TestUserViews(TestCaseDatabase):

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -505,7 +505,6 @@ class TestWebservices(TestCaseDatabase):
         # Owner tries to modify owner permissions
         url = url_for('permissionview', library=library_id)
         for permission_type in ['read', 'write', 'admin', 'owner']:
-
             # E-mail requested should correspond to user
             with MockEmailService(stub_user):
                 response = self.client.post(


### PR DESCRIPTION
All the URLs are now encoded in base64, and have the trailing equals signs removed.

The URLs are then decoded when a request is sent back into UUIDs.