### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/adsabs/biblib-service.png?label=ready&title=Ready)](https://waffle.io/adsabs/biblib-service)
 [![Build Status](https://travis-ci.org/adsabs/biblib-service.svg?branch=master)](https://travis-ci.org/adsabs/biblib-service)
 [![Coverage Status](https://coveralls.io/repos/adsabs/biblib-service/badge.svg?branch=master)](https://coveralls.io/r/adsabs/biblib-service?branch=master)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/adsabs/biblib-service

This was requested by a real person (user jonnybazookatone) on waffle.io, we're not trying to spam you.