### PR TITLE
Feature/library put update meta data

### DIFF
--- a/biblib/app.py
+++ b/biblib/app.py
@@ -47,7 +47,7 @@ def create_app(config_type='STAGING'):
 
     api.add_resource(DocumentView,
                      '/documents/<string:library>',
-                     methods=['POST', 'DELETE'])
+                     methods=['POST', 'DELETE', 'PUT'])
 
     api.add_resource(PermissionView,
                      '/permissions/<string:library>',

--- a/biblib/tests/functional_tests/test_mistake_epic.py
+++ b/biblib/tests/functional_tests/test_mistake_epic.py
@@ -81,29 +81,79 @@ class TestMistakeEpic(TestCaseDatabase):
             self.assertEqual(library_description,
                              DEFAULT_LIBRARY_DESCRIPTION)
 
-        # Mary updates the name and description of the library to something
+        # Mary decides to update the name of the library to something more
         # sensible
-        for meta_data, update in [['name', 'test'], ['description', 'test2']]:
+        name = 'something sensible'
 
-            # Make the change
-            url = url_for('documentview', library=library_id)
-            response = self.client.put(
-                url,
-                data=stub_library.document_view_put_data_json(
-                    meta_data, update
-                ),
-                headers=user_mary.headers
-            )
-            self.assertEqual(response.status_code, 200)
+        url = url_for('documentview', library=library_id)
+        response = self.client.put(
+            url,
+            data=stub_library.document_view_put_data_json(
+                name=name
+            ),
+            headers=user_mary.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['name'], name)
 
-            # Check the change worked
-            url = url_for('userview', library=library_id)
-            response = self.client.get(
-                url,
-                headers=user_mary.headers
-            )
-            self.assertEqual(update,
-                             response.json['libraries'][0][meta_data])
+        # She checks the change worked
+        url = url_for('userview', library=library_id)
+        response = self.client.get(
+            url,
+            headers=user_mary.headers
+        )
+        self.assertEqual(name,
+                         response.json['libraries'][0]['name'])
+
+        # Mary decides to make the description also more relevant
+        description = 'something relevant'
+        url = url_for('documentview', library=library_id)
+        response = self.client.put(
+            url,
+            data=stub_library.document_view_put_data_json(
+                description=description
+            ),
+            headers=user_mary.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['description'], description)
+
+        # Mary checks that the change worked
+        url = url_for('userview', library=library_id)
+        response = self.client.get(
+            url,
+            headers=user_mary.headers
+        )
+        self.assertEqual(description,
+                         response.json['libraries'][0]['description'])
+
+        # Mary dislikes both her changes and makes both the changes at once
+        name = 'Disliked the other one'
+        description = 'It didn\'t make sense before'
+        url = url_for('documentview', library=library_id)
+        response = self.client.put(
+            url,
+            data=stub_library.document_view_put_data_json(
+                name=name,
+                description=description
+            ),
+            headers=user_mary.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['name'], name)
+        self.assertEqual(response.json['description'], description)
+
+        # Check the change worked
+        url = url_for('userview', library=library_id)
+        response = self.client.get(
+            url,
+            headers=user_mary.headers
+        )
+        self.assertEqual(name,
+                         response.json['libraries'][0]['name'])
+        self.assertEqual(description,
+                         response.json['libraries'][0]['description'])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/biblib/tests/functional_tests/test_mistake_epic.py
+++ b/biblib/tests/functional_tests/test_mistake_epic.py
@@ -17,6 +17,7 @@ import unittest
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from tests.base import TestCaseDatabase
+from views import DEFAULT_LIBRARY_NAME_PREFIX, DEFAULT_LIBRARY_DESCRIPTION
 
 class TestMistakeEpic(TestCaseDatabase):
     """
@@ -35,7 +36,7 @@ class TestMistakeEpic(TestCaseDatabase):
 
         # Stub data
         user_mary = UserShop()
-        stub_library = LibraryShop()
+        stub_library = LibraryShop(name='', description='')
 
         # Mary creates a private library and
         # Does not fill any of the details requested, and then looks at the
@@ -47,18 +48,48 @@ class TestMistakeEpic(TestCaseDatabase):
             headers=user_mary.headers
         )
         library_id = response.json['id']
+        library_name = response.json['name']
+        library_description = response.json['description']
         self.assertEqual(response.status_code, 200, response)
-        self.assertTrue('name' in response.json)
-        self.assertTrue(response.json['name'] == stub_library.name)
+        self.assertTrue('name' in response.json, response.json)
+        self.assertTrue(response.json['name'] != '')
 
-        # Mary updates the name and description of the library
+        # Mary updates the name and description of the library, but leaves the
+        # details blank. This should not update the names as we do not want
+        # them as blank.
+        for meta_data, update in [['name', ''], ['description', '']]:
+
+            # Make the change
+            url = url_for('documentview', library=library_id)
+            response = self.client.put(
+                url,
+                data=stub_library.document_view_put_data_json(
+                    meta_data, update
+                ),
+                headers=user_mary.headers
+            )
+            self.assertEqual(response.status_code, 200)
+
+            # Check the change did not work
+            url = url_for('userview', library=library_id)
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+            self.assertEqual(library_name,
+                             '{0} 1'.format(DEFAULT_LIBRARY_NAME_PREFIX))
+            self.assertEqual(library_description,
+                             DEFAULT_LIBRARY_DESCRIPTION)
+
+        # Mary updates the name and description of the library to something
+        # sensible
         for meta_data, update in [['name', 'test'], ['description', 'test2']]:
 
             # Make the change
-            url = url_for('documentview')
+            url = url_for('documentview', library=library_id)
             response = self.client.put(
                 url,
-                data=stub_library.document_view_pust_data_json(
+                data=stub_library.document_view_put_data_json(
                     meta_data, update
                 ),
                 headers=user_mary.headers
@@ -66,12 +97,13 @@ class TestMistakeEpic(TestCaseDatabase):
             self.assertEqual(response.status_code, 200)
 
             # Check the change worked
-            url = url_for('libraryview', library=library_id)
+            url = url_for('userview', library=library_id)
             response = self.client.get(
                 url,
                 headers=user_mary.headers
             )
-            self.assertTrue('test', response.json['name'])
+            self.assertEqual(update,
+                             response.json['libraries'][0][meta_data])
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -274,5 +274,6 @@ class LibraryShop(object):
 
         :return: PUT data in JSON format
         """
-        put_data = self.document_view_put_data(name, description)
+        put_data = self.document_view_put_data(name=name,
+                                               description=description)
         return json.dumps(put_data)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -177,6 +177,10 @@ class LibraryShop(object):
     bibcode: bibcode
     action: add/remove
 
+    PUT
+    ----
+    name: name
+    description: description
     """
 
     def __init__(self, **kwargs):
@@ -195,6 +199,12 @@ class LibraryShop(object):
             setattr(self, key, self.stub.__dict__[key])
 
         self.kwargs = kwargs
+
+        if self.kwargs:
+            for key in self.kwargs:
+                if key in self.__dict__.keys():
+                    setattr(self, key, self.kwargs[key])
+
         self.create_user_view_post_data()
 
     def create_user_view_post_data(self):
@@ -207,15 +217,8 @@ class LibraryShop(object):
         post_data = dict(
             name=self.name,
             description=self.description,
-            read=False,
-            write=False,
-            public=False
+            public=self.public
         )
-
-        if self.kwargs:
-            for key in self.kwargs:
-                if key in post_data.keys():
-                    post_data[key] = self.kwargs[key]
 
         json_data = json.dumps(post_data)
 
@@ -246,3 +249,30 @@ class LibraryShop(object):
         """
         post_data = self.document_view_post_data(action)
         return json.dumps(post_data)
+
+    def document_view_put_data(self, name='', description=''):
+        """
+        Expected data to be sent in a PUT request to the DocumentView
+        end point, /documents/<>
+        :param name: name of the library to change it to
+        :param description: description to change it to
+
+        :return: PUT data in dictionary format
+        """
+        put_data = dict(
+            name=name,
+            description=description
+        )
+        return put_data
+
+    def document_view_put_data_json(self, name='', description=''):
+        """
+        Expected data to be sent in a PUT request to the DocumentView
+        end point, /documents/<>
+        :param name: name of the library to change it to
+        :param description: description to change it to
+
+        :return: PUT data in JSON format
+        """
+        put_data = self.document_view_put_data(name, description)
+        return json.dumps(put_data)

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -714,8 +714,8 @@ class TestDocumentViews(TestCaseDatabase):
                            description=new_description,
                            random=random_text)
 
-        self.document_view.update_library_meta_data(library_id=library.id,
-                                                    library_data=update_data)
+        self.document_view.update_library(library_id=library.id,
+                                          library_data=update_data)
 
         new_library = Library.query.filter(Library.id == library.id).one()
         self.assertEqual(new_library.name, new_name)
@@ -723,7 +723,6 @@ class TestDocumentViews(TestCaseDatabase):
         with self.assertRaises(AttributeError):
             library.random
 
-    @unittest.skip('Not implemented')
     def test_can_update_libraries_details_if_owner_or_admin(self):
         """
         Tests that a user can update the libraries details, such as name and

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -229,6 +229,56 @@ class BaseView(Resource):
         except NoResultFound:
             return False
 
+    def helper_validate_library_data(self, service_uid, library_data):
+        """
+        Validates the library data to ensure the user does not give empty
+        content for the title and description.
+
+        :param service_uid: the user ID within this microservice
+        :param library_data: content needed to create a library
+
+        :return: validated name and description
+        """
+
+        _name = library_data.get('name') or DEFAULT_LIBRARY_NAME_PREFIX
+        _description = library_data.get('description') or \
+            DEFAULT_LIBRARY_DESCRIPTION
+
+        current_app.logger.info('Creating library for user_service: {0:d}, '
+                                'with properties: {1}'
+                                .format(service_uid, library_data))
+
+        # We want to ensure that the users have unique library names. However,
+        # it should be possible that they have access to other libraries from
+        # other people, that have the same name
+        library_names = \
+            [i.library.name for i in
+             Permissions.query.filter(Permissions.user_id == service_uid,
+                                      Permissions.owner == True).all()]
+
+        matches = [name for name in library_names if name == _name]
+        if matches:
+            current_app.logger.error('Name supplied for the library already '
+                                     'exists: "{0}" ["{1}"]'.format(_name,
+                                                                    matches))
+            raise BackendIntegrityError('Library name already exists.')
+
+        if _name == DEFAULT_LIBRARY_NAME_PREFIX:
+            default_names = [lib_name for lib_name
+                             in library_names
+                             if DEFAULT_LIBRARY_NAME_PREFIX
+                             in lib_name]
+
+            _extension = len(default_names) + 1
+            _name = '{0} {1}'.format(_name,
+                                     _extension)
+
+        library_data['name'] = _name
+        library_data['description'] = _description
+
+        return library_data
+
+
 class UserView(BaseView):
     """
     End point to create a library for a given user
@@ -269,37 +319,13 @@ class UserView(BaseView):
         :return: no return
         """
 
-        _name = library_data.get('name') or DEFAULT_LIBRARY_NAME_PREFIX
-        _description = library_data.get('description') or \
-            DEFAULT_LIBRARY_DESCRIPTION
+        library_data = self.helper_validate_library_data(
+            service_uid=service_uid,
+            library_data=library_data
+        )
+        _name = library_data.get('name')
+        _description = library_data.get('description')
         _public = bool(library_data.get('public', False))
-
-        current_app.logger.info('Creating library for user_service: {0:d}, '
-                                'with properties: {1}'
-                                .format(service_uid, library_data))
-
-        # We want to ensure that the users have unique library names. However,
-        # it should be possible that they have access to other libraries from
-        # other people, that have the same name
-        library_names = \
-            [i.library.name for i in
-             Permissions.query.filter(Permissions.user_id == service_uid,
-                                      Permissions.owner == True).all()]
-
-        if _name in library_names:
-            current_app.logger.error('Name supplied for the library already '
-                                     'exists: "{0}"'.format(_name))
-            raise BackendIntegrityError('Library name already exists.')
-
-        if _name == DEFAULT_LIBRARY_NAME_PREFIX:
-            default_names = [lib_name for lib_name
-                             in library_names
-                             if DEFAULT_LIBRARY_NAME_PREFIX
-                             in lib_name]
-
-            _extension = len(default_names) + 1
-            _name = '{0} {1}'.format(_name,
-                                     _extension)
 
         try:
 
@@ -586,13 +612,10 @@ class DocumentView(BaseView):
     End point to interact with a specific library, by adding documents and
     removing documents. You also use this endpoint to delete the entire
     library as this method should be scoped.
-
-    XXX: need to ignore the anon user, they should not be able to do anything
-    XXX: document already exists (only add a bibcode once)
-    XXX: adding tags using PUT for RESTful endpoint?
-    XXX: public/private behaviour
-
     """
+    # TODO: adding tags using PUT for RESTful endpoint?
+    # TODO: normalise input and check the content delivered. Can be placed in
+    # its own function
 
     decorators = [advertise('scopes', 'rate_limit')]
     scopes = ['scope1', 'scope2']
@@ -649,17 +672,20 @@ class DocumentView(BaseView):
         :return:
         """
         updateable = ['name', 'description']
+        updated = {}
 
         library = Library.query.filter(Library.id == library_id).one()
 
         for key in library_data:
             if key not in updateable:
                 continue
-
             setattr(library, key, library_data[key])
+            updated[key] = library_data[key]
 
         db.session.add(library)
         db.session.commit()
+
+        return updated
 
     def delete_library(self, library_id):
         """
@@ -672,6 +698,24 @@ class DocumentView(BaseView):
         library = Library.query.filter(Library.id == library_id).one()
         db.session.delete(library)
         db.session.commit()
+
+    def update_access(self, service_uid, library_id):
+        """
+        Defines which type of user has delete permissions to a library.
+
+        :param service_uid: the user ID within this microservice
+        :param library_id: the unique ID of the library
+
+        :return: boolean, access (True), no access (False)
+        """
+        update_allowed = ['admin', 'owner']
+        for access_type in update_allowed:
+            if self.helper_access_allowed(service_uid=service_uid,
+                                          library_id=library_id,
+                                          access_type=access_type):
+                return True
+
+        return False
 
     def delete_access(self, service_uid, library_id):
         """
@@ -705,6 +749,21 @@ class DocumentView(BaseView):
                 return True
 
         return False
+
+    def library_name_exists(self, service_uid, library_name):
+
+        library_names = \
+            [i.library.name for i in
+             Permissions.query.filter(Permissions.user_id == service_uid,
+                                      Permissions.owner == True).all()]
+
+        if library_name in library_names:
+            current_app.logger.error('Name supplied for the library already '
+                                     'exists: "{0}"'.format(library_name))
+
+            return True
+        else:
+            return False
 
     def post(self, library):
         """
@@ -788,8 +847,54 @@ class DocumentView(BaseView):
         ---------
         tba
         """
+        # TODO: see above, there is DRY here!
 
-        return {}, 200
+        try:
+            user = self.helper_get_user_id()
+        except KeyError:
+            return {'error': MISSING_USERNAME_ERROR['body']}, \
+                MISSING_USERNAME_ERROR['number']
+
+        # URL safe base64 string to UUID
+        library = self.helper_slug_to_uuid(library)
+
+        if not self.helper_user_exists(user):
+            return {'error': NO_PERMISSION_ERROR['body']}, \
+                NO_PERMISSION_ERROR['number']
+
+        if not self.helper_library_exists(library):
+            return {'error': MISSING_LIBRARY_ERROR['body']}, \
+                MISSING_LIBRARY_ERROR['number']
+
+        user_updating_uid = \
+            self.helper_absolute_uid_to_service_uid(absolute_uid=user)
+
+        if not self.update_access(service_uid=user_updating_uid,
+                                  library_id=library):
+            return {'error': NO_PERMISSION_ERROR['body']}, \
+                NO_PERMISSION_ERROR['number']
+
+        library_data = get_post_data(request)
+
+        # Remove content that is empty
+        for key in library_data.keys():
+            if not library_data[key]:
+                current_app.logger.warning('Removing key: {0} as its empty.'
+                                           .format(key))
+                library_data.pop(key)
+
+        # Check for duplicate namaes
+        if 'name' in library_data and \
+                self.library_name_exists(service_uid=user_updating_uid,
+                                         library_name=library_data['name']):
+
+                return {'error': DUPLICATE_LIBRARY_NAME_ERROR['body']}, \
+                   DUPLICATE_LIBRARY_NAME_ERROR['number']
+
+        response = self.update_library(library_id=library,
+                                       library_data=library_data)
+
+        return response, 200
 
     def delete(self, library):
         """

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -641,6 +641,26 @@ class DocumentView(BaseView):
         current_app.logger.info('Removed document successfully: {0}'
                                 .format(library.bibcode))
 
+    def update_library(self, library_id, library_data):
+        """
+        Update the meta data of the library
+        :param library_id: the unique ID of the library
+
+        :return:
+        """
+        updateable = ['name', 'description']
+
+        library = Library.query.filter(Library.id == library_id).one()
+
+        for key in library_data:
+            if key not in updateable:
+                continue
+
+            setattr(library, key, library_data[key])
+
+        db.session.add(library)
+        db.session.commit()
+
     def delete_library(self, library_id):
         """
         Delete the entire library from the database


### PR DESCRIPTION
This closes issues 32 and 41.

A library is created with a default library name 'Untitled Library + <int:N>'.
A library is created with a default description 'My ADS library'.

There is now a PUT end point for the UserView, at /libraries/<string:library>.
The user must have the permissions of 'admin' or 'owner' to update the name
or the description.
The user can only update either 'name' or 'description'. If they pass any other
information, it will be ignored. The return contains the updated value.

Relevant functional, view, and webservices tests have been included.