### PR TITLE
Issue #36

### DIFF
--- a/biblib/models.py
+++ b/biblib/models.py
@@ -88,6 +88,28 @@ class MutableList(Mutable, list):
         list.remove(self, value)
         self.changed()
 
+    def extend(self, value):
+        """
+        Define an extend action
+        :param value: list to extend with
+
+        :return: no return
+        """
+        list.extend(self, value)
+        self.changed()
+
+    def shorten(self, value):
+        """
+        Define a shorten action. Opposite to extend
+
+        :param value: values to remove
+
+        :return: no return
+        """
+        for item in value:
+            self.remove(item)
+
+
     @classmethod
     def coerce(cls, key, value):
         """

--- a/biblib/tests/functional_tests/test_job_fast_epic.py
+++ b/biblib/tests/functional_tests/test_job_fast_epic.py
@@ -1,0 +1,86 @@
+"""
+Functional test
+
+Job Epic
+
+Storyboard is defined within the comments of the program itself
+"""
+
+import sys
+import os
+
+PROJECT_HOME = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../'))
+sys.path.append(PROJECT_HOME)
+
+import unittest
+from views import DUPLICATE_DOCUMENT_NAME_ERROR
+from flask import url_for
+from tests.stubdata.stub_data import UserShop, LibraryShop
+from tests.base import TestCaseDatabase
+
+class TestJobEpic(TestCaseDatabase):
+    """
+    Base class used to test the Job Epic
+    """
+
+    def test_job_epic(self):
+        """
+        Carries out the epic 'Job', where a user wants to add their articles to
+        their private libraries so that they can send it on to a prospective
+        employer
+
+        :return: no return
+        """
+
+        # Mary creates a private library and
+        #   1. Gives it a name.
+        #   2. Gives it a description.
+        #   3. Makes it public to view.
+
+        # Stub data
+        user_mary = UserShop()
+        user_random = UserShop()
+        stub_library = LibraryShop(want_bibcode=True, public=True)
+
+        self.assertIs(list, type(stub_library.bibcode))
+        self.assertIs(list, type(stub_library.user_view_post_data['bibcode']))
+
+        # Make the library and make it public to be viewed by employers
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library.user_view_post_data_json,
+            headers=user_mary.headers
+        )
+        library_id = response.json['id']
+        self.assertEqual(response.status_code, 200, response)
+        self.assertTrue('bibcode' in response.json)
+        self.assertTrue(response.json['name'] == stub_library.name)
+
+        # She then asks a friend to check the link, and it works fine.
+        url = url_for('libraryview', library=library_id)
+        response = self.client.get(
+            url,
+            headers=user_random.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json['documents']),
+                         len(stub_library.bibcode))
+
+        # Accidentally tries to add the same bibcodes, but it does not work as
+        # expected
+        url = url_for('documentview', library=library_id)
+        response = self.client.post(
+            url,
+            data=stub_library.document_view_post_data_json('add'),
+            headers=user_mary.headers
+        )
+        self.assertEqual(response.status_code,
+                         DUPLICATE_DOCUMENT_NAME_ERROR['number'])
+        self.assertEqual(response.json['error'],
+                         DUPLICATE_DOCUMENT_NAME_ERROR['body'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -21,11 +21,15 @@ def fake_bibcode():
     """
     year = faker.year()
     author = faker.random_letter().upper()
-    provider = 3*author
+    provider = author
+    for i in range(2):
+        provider += faker.random_letter().upper()
+
     bibcode = '{year}.....{provider}......{author}'\
         .format(year=year,
                 provider=provider,
                 author=author)
+    
     return bibcode
 
 
@@ -75,7 +79,7 @@ class LibraryFactory(factory.Factory):
     public = False
     read = False
     write = False
-    bibcode = factory.LazyAttribute(lambda x: fake_biblist(nb_codes=1)[0])
+    bibcode = factory.LazyAttribute(lambda x: fake_biblist(nb_codes=1))
 
 
 class UserShop(object):
@@ -195,10 +199,20 @@ class LibraryShop(object):
         self.user_view_post_data = None
         self.user_view_post_data_json = None
 
+        self.kwargs = kwargs
+
+        self.want_bibcode = False
+
+        self.init_values()
+
+    def init_values(self):
+        """
+        Initialise all the values
+
+        :return:
+        """
         for key in self.stub.__dict__.keys():
             setattr(self, key, self.stub.__dict__[key])
-
-        self.kwargs = kwargs
 
         if self.kwargs:
             for key in self.kwargs:
@@ -219,6 +233,9 @@ class LibraryShop(object):
             description=self.description,
             public=self.public
         )
+
+        if self.want_bibcode:
+            post_data['bibcode'] = self.bibcode
 
         json_data = json.dumps(post_data)
 


### PR DESCRIPTION
Added:

Can include bibcode: [...] to POST when you create a library via the /libraries
end point.

Functionality test for creating a library and passing bibcodes on the creation.

Extend and shorten methods to MutableLists in the models. This means the lists
can be directly added to the current list, and all items within a list can be
removed from the existing list.

Lists are also made unique before being passed for creation. Duplication tests
were also added for the documents. Users should not be able to pass bibcodes that
are already in the list. It is probably worth checking if a unique constrain can
be placed on the content of a postgreSQL ARRAY.

Changed:

Add/remove of bibcodes now expect a bibcode with a type of list.

Tests updated to reflect the new type of bibcode.

Documentation updated for the methods and the '# TODO:' items moved out of the
class definition and left as comments within the class instead. This removes the
spam from the /resources end points.