### PR TITLE
Closes issue #30. Feature/issue 30/updating get data

### DIFF
--- a/biblib/migrations/versions/1c79c6e22cd5_.py
+++ b/biblib/migrations/versions/1c79c6e22cd5_.py
@@ -1,14 +1,14 @@
-"""First migrate
+"""dates included in models
 
-Revision ID: 4fc01902d29f
-Revises: None
-Create Date: 2015-06-01 14:46:04.498021
+Revision ID: 1c79c6e22cd5
+Revises: 4fc01902d29f
+Create Date: 2015-06-08 10:02:01.216103
 
 """
 
 # revision identifiers, used by Alembic.
-revision = '4fc01902d29f'
-down_revision = None
+revision = '1c79c6e22cd5'
+down_revision = '4fc01902d29f'
 
 from alembic import op
 import sqlalchemy as sa
@@ -22,6 +22,8 @@ def upgrade():
     sa.Column('description', sa.String(length=50), nullable=True),
     sa.Column('public', sa.Boolean(), nullable=True),
     sa.Column('bibcode', postgresql.ARRAY(sa.String(length=50)), nullable=True),
+    sa.Column('date_created', sa.DateTime(), nullable=False),
+    sa.Column('date_last_modified', sa.DateTime(), nullable=False),
     sa.PrimaryKeyConstraint('id')
     )
     op.create_table('user',

--- a/biblib/models.py
+++ b/biblib/models.py
@@ -140,8 +140,7 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     absolute_uid = db.Column(db.Integer, unique=True)
     permissions = db.relationship('Permissions',
-                                  backref='user',
-                                  cascade='delete')
+                                  backref='user')
 
     def __repr__(self):
         return '<User {0}, {1}>'\

--- a/biblib/models.py
+++ b/biblib/models.py
@@ -6,6 +6,7 @@ to be passed to the app creator within the Flask blueprint.
 """
 
 import uuid
+from datetime import datetime
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.ext.mutable import Mutable
@@ -109,7 +110,6 @@ class MutableList(Mutable, list):
         for item in value:
             self.remove(item)
 
-
     @classmethod
     def coerce(cls, key, value):
         """
@@ -139,7 +139,9 @@ class User(db.Model):
     __tablename__ = 'user'
     id = db.Column(db.Integer, primary_key=True)
     absolute_uid = db.Column(db.Integer, unique=True)
-    permissions = db.relationship('Permissions', backref='user')
+    permissions = db.relationship('Permissions',
+                                  backref='user',
+                                  cascade='delete')
 
     def __repr__(self):
         return '<User {0}, {1}>'\
@@ -159,7 +161,20 @@ class Library(db.Model):
     description = db.Column(db.String(50))
     public = db.Column(db.Boolean)
     bibcode = db.Column(MutableList.as_mutable(ARRAY(db.String(50))))
-    permissions = db.relationship('Permissions', backref='library')
+    date_created = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.utcnow
+    )
+    date_last_modified = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow
+    )
+    permissions = db.relationship('Permissions',
+                                  backref='library',
+                                  cascade='delete')
 
     def __repr__(self):
         return '<Library, library_id: {0} name: {1}, ' \
@@ -195,5 +210,6 @@ class Permissions(db.Model):
 
     def __repr__(self):
         return '<Permissions, user_id: {0}, library_id: {1}, read: {2}, '\
-               'write: {3}'\
-            .format(self.user_id, self.library_id, self.read, self.write)
+               'write: {3}, admin: {4}, owner: {5}'\
+            .format(self.user_id, self.library_id, self.read, self.write,
+                    self.admin, self.owner)

--- a/biblib/tests/functional_tests/test_deletion_epic.py
+++ b/biblib/tests/functional_tests/test_deletion_epic.py
@@ -81,7 +81,6 @@ class TestDeletionEpic(TestCaseDatabase):
             url,
             headers=stub_user.headers
         )
-        print response.json
         self.assertTrue(len(response.json['libraries']) == 2)
         library_id_1 = response.json['libraries'][0]['id']
         library_id_2 = response.json['libraries'][1]['id']
@@ -100,7 +99,6 @@ class TestDeletionEpic(TestCaseDatabase):
             url,
             headers=stub_user.headers
         )
-        print response.json
         self.assertTrue(len(response.json['libraries']) == 1)
 
         # Deletes the first library

--- a/biblib/tests/functional_tests/test_deletion_epic.py
+++ b/biblib/tests/functional_tests/test_deletion_epic.py
@@ -81,6 +81,8 @@ class TestDeletionEpic(TestCaseDatabase):
             url,
             headers=stub_user.headers
         )
+        print response.json
+        self.assertTrue(len(response.json['libraries']) == 2)
         library_id_1 = response.json['libraries'][0]['id']
         library_id_2 = response.json['libraries'][1]['id']
 
@@ -92,12 +94,13 @@ class TestDeletionEpic(TestCaseDatabase):
         )
         self.assertEqual(response.status_code, 200)
 
-        # Looks to check there are is only one libraries
+        # Looks to check there are is only one library
         url = url_for('userview')
         response = self.client.get(
             url,
             headers=stub_user.headers
         )
+        print response.json
         self.assertTrue(len(response.json['libraries']) == 1)
 
         # Deletes the first library

--- a/biblib/tests/functional_tests/test_returned_data_epic.py
+++ b/biblib/tests/functional_tests/test_returned_data_epic.py
@@ -1,0 +1,189 @@
+"""
+Functional test
+
+Returned Data Epic
+
+Storyboard is defined within the comments of the program itself
+"""
+
+import sys
+import os
+
+PROJECT_HOME = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../'))
+sys.path.append(PROJECT_HOME)
+
+import time
+import unittest
+from datetime import datetime, timedelta
+from flask import url_for
+from tests.stubdata.stub_data import UserShop, LibraryShop
+from tests.base import MockEmailService, TestCaseDatabase
+
+
+class TestReturnedDataEpic(TestCaseDatabase):
+    """
+    Base class used to test the Big Share Epic
+    """
+
+    def test_returned_data_user_view_epic(self):
+        """
+        Carries out the epic 'Returned Data', for the UserView GET end point
+
+        :return: no return
+        """
+
+        # Stub data
+        user_dave = UserShop()
+        user_mary = UserShop()
+
+        stub_library = LibraryShop()
+
+        # Librarian Dave makes a library (no bibcodes)
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library.user_view_post_data_json,
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200, response)
+        library_id_dave = response.json['id']
+
+        # Dave looks at the library from the user view page and checks some
+        # of the parameters displayed to him.
+        response = self.client.get(
+            url,
+            headers=user_dave.headers
+        )
+        self.assertTrue(len(response.json['libraries']) == 1)
+        library = response.json['libraries'][0]
+        self.assertTrue(library['num_documents'] == 0)
+        self.assertTrue(library['num_users'] == 1)
+        self.assertTrue(library['permission'] == 'owner')
+        self.assertEqual(library['public'], False)
+        date_created = datetime.strptime(library['date_created'],
+                                         '%Y-%m-%dT%H:%M:%S.%f')
+        date_last_modified = datetime.strptime(library['date_last_modified'],
+                                               '%Y-%m-%dT%H:%M:%S.%f')
+        self.assertAlmostEqual(date_created,
+                               date_last_modified,
+                               delta=timedelta(seconds=1))
+
+        # Dave adds content to his library
+        number_of_documents = 20
+        for i in range(number_of_documents):
+
+            # Stub data
+            library = LibraryShop()
+
+            # Add document
+            url = url_for('documentview', library=library_id_dave)
+            response = self.client.post(
+                url,
+                data=library.document_view_post_data_json('add'),
+                headers=user_dave.headers
+            )
+            self.assertEqual(response.status_code, 200, response)
+
+        # Dave looks in the library overview and sees that his library size
+        # has increased
+        url = url_for('userview')
+        response = self.client.get(
+            url,
+            headers=user_dave.headers
+        )
+        self.assertTrue(len(response.json['libraries'])==1)
+        self.assertEqual(response.status_code, 200)
+        library = response.json['libraries'][0]
+        self.assertTrue(library['num_documents'] == number_of_documents)
+
+        # Dave adds mary so that she can see the library and add content
+        url = url_for('permissionview', library=library_id_dave)
+        with MockEmailService(user_mary):
+            response = self.client.post(
+                url,
+                data=user_mary.permission_view_post_data_json('admin', True),
+                headers=user_dave.headers
+            )
+        self.assertEqual(response.status_code, 200)
+
+        # Mary sees that the number of users of the library has increased by 1
+        url = url_for('userview')
+        response = self.client.get(
+            url,
+            headers=user_mary.headers
+        )
+
+        library = response.json['libraries'][0]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(library['num_users'] == 2)
+        self.assertTrue(library['permission'] == 'admin')
+
+        # Mary adds content to the library
+        number_of_documents_second = 1
+        for i in range(number_of_documents_second):
+
+            # Stub data
+            library = LibraryShop()
+
+            # Add document
+            url = url_for('documentview', library=library_id_dave)
+            response = self.client.post(
+                url,
+                data=library.document_view_post_data_json('add'),
+                headers=user_mary.headers
+            )
+            self.assertEqual(response.status_code, 200, response)
+
+        # Dave sees that the number of bibcodes has increased and that the
+        # last modified date has changed, but the created date has not
+        url = url_for('userview')
+        response = self.client.get(
+            url,
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json['libraries']) == 1)
+        self.assertTrue(
+            response.json['libraries'][0]['num_documents']
+            == (number_of_documents+number_of_documents_second)
+        )
+
+        # This is to artificial alter the update time
+        time.sleep(1)
+
+        # Dave makes the library public.
+        url = url_for('documentview', library=library_id_dave)
+        response = self.client.put(
+            url,
+            data=library.document_view_put_data_json(public=True),
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Dave sees that the lock sign from his library page has dissapeared
+        url = url_for('userview')
+        response = self.client.get(
+            url,
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        libraries = response.json['libraries']
+        self.assertTrue(len(libraries) == 1)
+        self.assertTrue(
+            libraries[0]['num_documents'] == number_of_documents+1
+        )
+        self.assertTrue(libraries[0]['public'])
+        date_created_2 = datetime.strptime(libraries[0]['date_created'],
+                                           '%Y-%m-%dT%H:%M:%S.%f')
+        date_last_modified_2 = \
+            datetime.strptime(libraries[0]['date_last_modified'],
+                              '%Y-%m-%dT%H:%M:%S.%f')
+        self.assertEqual(date_created, date_created_2)
+        self.assertNotAlmostEqual(date_created_2,
+                                  date_last_modified_2,
+                                  delta=timedelta(seconds=1))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -267,7 +267,7 @@ class LibraryShop(object):
         post_data = self.document_view_post_data(action)
         return json.dumps(post_data)
 
-    def document_view_put_data(self, name='', description=''):
+    def document_view_put_data(self, name='', description='', public=''):
         """
         Expected data to be sent in a PUT request to the DocumentView
         end point, /documents/<>
@@ -278,11 +278,12 @@ class LibraryShop(object):
         """
         put_data = dict(
             name=name,
-            description=description
+            description=description,
+            public=public
         )
         return put_data
 
-    def document_view_put_data_json(self, name='', description=''):
+    def document_view_put_data_json(self, name='', description='', public=''):
         """
         Expected data to be sent in a PUT request to the DocumentView
         end point, /documents/<>
@@ -292,5 +293,19 @@ class LibraryShop(object):
         :return: PUT data in JSON format
         """
         put_data = self.document_view_put_data(name=name,
-                                               description=description)
+                                               description=description,
+                                               public=public)
         return json.dumps(put_data)
+
+    @staticmethod
+    def user_view_get_response():
+        """
+        Expected return data from the user view GET end point
+
+        :return: GET data in dictionary format
+        """
+
+        expected_types = ['name', 'description', 'id', 'num_documents',
+                          'date_created', 'date_last_modified', 'permission',
+                          'public', 'num_users']
+        return expected_types

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -129,7 +129,7 @@ class TestWebservices(TestCaseDatabase):
             self.assertEqual(stub_library.description,
                              library['description'])
 
-    def test_create_library_resource(self):
+    def test_create_library_resource_response_content(self):
         """
         Test the /libraries GET end point
         Ensuring the response contains the data we expect. For now, this is

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -284,10 +284,13 @@ class BaseView(Resource):
             _name = '{0} {1}'.format(_name,
                                      _extension)
 
-        library_data['name'] = _name
-        library_data['description'] = _description
+        library_out = {}
+        for key in library_data:
+            library_out[key] = library_data[key]
+        library_out['name'] = _name
+        library_out['description'] = _description
 
-        return library_data
+        return library_out
 
 
 class UserView(BaseView):
@@ -405,17 +408,13 @@ class UserView(BaseView):
         # Get all the permissions for a user
         # This can be improved into one database call rather than having
         # one per each permission, but needs some checks in place.
-        user_permissions = Permissions.query.filter(
-            Permissions.user_id == service_uid
-        ).all()
+        result = db.session.query(Permissions, Library)\
+            .join(Permissions.library)\
+            .filter(Permissions.user_id == service_uid)\
+            .all()
 
         output_libraries = []
-        for permission in user_permissions:
-
-            # For this permission get the library
-            library = Library.query.filter(
-                Library.id == permission.library_id
-            ).one()
+        for permission, library in result:
 
             # For this library get all the people who have permissions
             users = Permissions.query.filter(


### PR DESCRIPTION
The /libraries end point was updated to include:
    
  * num_users: the number of users that have permissions for a library. 
    * Only the admin and owner can see this information, otherwise it defaults to zero
  * num_documents: number of bibcodes in a library
  * date_created
  * date_last_modified
  * permission: finds the highest ranking permissions and returns that
  * Relevant tests have been included. 
  * Migrations for the database changes included in this commit.
  * Added a few tests to ensure that permissions get deleted when a library is deleted.
  * Added a few tests to ensure the get libraries join is working as is expected.