### PR TITLE
Issue #23: additions to catch errors from the API user resolver

### DIFF
--- a/biblib/tests/base.py
+++ b/biblib/tests/base.py
@@ -44,7 +44,11 @@ class MockADSWSAPI(object):
                 resp_dict[key] = self.response_kwargs[key]
 
             resp = json.dumps(resp_dict)
-            return 200, headers, resp
+
+            if self.response_kwargs['fail']:
+                return 404, headers, {}
+            else:
+                return 200, headers, resp
 
         HTTPretty.register_uri(
             HTTPretty.GET,
@@ -92,9 +96,14 @@ class MockEmailService(MockADSWSAPI):
             ep=ep
         )
 
+        fail = False
+        if stub_user.name == 'fail':
+            fail = True
+
         response_kwargs = {
             'uid': stub_user.absolute_uid,
             'email': stub_user.email,
+            'fail': fail,
         }
 
         super(MockEmailService, self).__init__(


### PR DESCRIPTION
The following is applied:

  1. If the e-mail does not exist in the API, it returns a 404 error
     that is propogated from the API end point.
  2. If the UID does not exist in the API, the library is still
     returned, with the username as 'Not available'. This assumes
     that there is an issue with the accounts system. It is also
     possible that the user may have been deleted, so this should
     also be considered at the stage at which we want to remove
     the users from the libraries based on the API.