### PR TITLE
Feature/issue 33/return solr data

### DIFF
--- a/biblib/test_config.py
+++ b/biblib/test_config.py
@@ -97,5 +97,6 @@ except KeyError:
 
 # These lines are necessary only if the app needs to be a client of the
 # adsws-api
+BIBLIB_SOLR_BIG_QUERY_URL = 'https://api.adsabs.search/v1/bigquery'
 BIBLIB_USER_EMAIL_ADSWS_API_URL = 'https://api.adsabs.harvard.edu/v1/user'
 BIBLIB_ADSWS_API_TOKEN = 'this is a secret api token!'

--- a/biblib/tests/base.py
+++ b/biblib/tests/base.py
@@ -14,7 +14,7 @@ class MockADSWSAPI(object):
     """
     Mock of the ADSWS API
     """
-    def __init__(self, api_endpoint, response_kwargs):
+    def __init__(self, api_endpoint, response_kwargs={}):
         """
         Constructor
         :param api_endpoint: name of the API end point
@@ -54,7 +54,7 @@ class MockADSWSAPI(object):
             HTTPretty.GET,
             self.api_endpoint,
             body=request_callback,
-            content_type="application/json"
+            content_type='application/json'
         )
 
     def __enter__(self):
@@ -77,7 +77,71 @@ class MockADSWSAPI(object):
         HTTPretty.reset()
         HTTPretty.disable()
 
+class MockSolrBigqueryService(MockADSWSAPI):
 
+    def __init__(self, **kwargs):
+
+        """
+        Constructor
+        :param api_endpoint: name of the API end point
+        :param user_uid: unique API user ID to be returned
+        :return: no return
+        """
+
+        self.kwargs = kwargs
+        self.api_endpoint = current_app.config['BIBLIB_SOLR_BIG_QUERY_URL']
+
+        def request_callback(request, uri, headers):
+            """
+            :param request: HTTP request
+            :param uri: URI/URL to send the request
+            :param headers: header of the HTTP request
+            :return:
+            """
+
+            resp_dict = {
+                'api-response': 'success',
+                'token': request.headers.get(
+                    'Authorization', 'No Authorization header passed!'
+                )
+            }
+
+            for key in self.kwargs:
+                resp_dict[key] = self.kwargs[key]
+
+            resp = json.dumps(resp_dict)
+
+            if 'fail' in self.kwargs:
+                return 404, headers, {}
+            else:
+                return 200, headers, resp
+
+        HTTPretty.register_uri(
+            HTTPretty.POST,
+            self.api_endpoint,
+            body=request_callback,
+            content_type='application/json'
+        )
+
+    def __enter__(self):
+        """
+        Defines the behaviour for __enter__
+        :return: no return
+        """
+
+        HTTPretty.enable()
+
+    def __exit__(self, etype, value, traceback):
+        """
+        Defines the behaviour for __exit__
+        :param etype: exit type
+        :param value: exit value
+        :param traceback: the traceback for the exit
+        :return: no return
+        """
+
+        HTTPretty.reset()
+        HTTPretty.disable()
 class MockEmailService(MockADSWSAPI):
 
     """

--- a/biblib/tests/base.py
+++ b/biblib/tests/base.py
@@ -99,22 +99,31 @@ class MockSolrBigqueryService(MockADSWSAPI):
             :return:
             """
 
-            resp_dict = {
-                'api-response': 'success',
-                'token': request.headers.get(
-                    'Authorization', 'No Authorization header passed!'
-                )
+            resp = {
+                'responseHeader': {
+                    'status': 0,
+                    'QTime': 152,
+                    'params': {
+                        'fl': 'bibcode',
+                        'q': '*:*',
+                        'wt': 'json'
+                    }
+                },
+                'response': {
+                    'numFound': 1,
+                    'start': 0,
+                    'docs': [
+                        {
+                            'bibcode': 'bibcode'
+                        }
+                    ]
+                }
             }
 
-            for key in self.kwargs:
-                resp_dict[key] = self.kwargs[key]
+            resp = json.dumps(resp)
 
-            resp = json.dumps(resp_dict)
-
-            if 'fail' in self.kwargs:
-                return 404, headers, {}
-            else:
-                return 200, headers, resp
+            status = self.kwargs.get('status', 200)
+            return status, headers, resp
 
         HTTPretty.register_uri(
             HTTPretty.POST,

--- a/biblib/tests/functional_tests/test_anonymous_epic.py
+++ b/biblib/tests/functional_tests/test_anonymous_epic.py
@@ -13,14 +13,11 @@ PROJECT_HOME = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../../'))
 sys.path.append(PROJECT_HOME)
 
-import app
-import json
 import unittest
 from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
-from models import db
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import TestCaseDatabase
+from tests.base import TestCaseDatabase, MockSolrBigqueryService
 
 class TestAnonymousEpic(TestCaseDatabase):
     """
@@ -66,19 +63,21 @@ class TestAnonymousEpic(TestCaseDatabase):
 
         # Anonymous user tries to access the private library. But cannot.
         url = url_for('libraryview', library=library_id_private)
-        response = self.client.get(
-            url,
-            headers=user_anonymous.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_anonymous.headers
+            )
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
 
         # Anonymous user tries to access the public library. And can.
         url = url_for('libraryview', library=library_id_public)
-        response = self.client.get(
-            url,
-            headers=user_anonymous.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_anonymous.headers
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertIn('documents', response.json)

--- a/biblib/tests/functional_tests/test_big_share_admin_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_admin_epic.py
@@ -13,14 +13,12 @@ PROJECT_HOME = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../../'))
 sys.path.append(PROJECT_HOME)
 
-import app
-import json
 import unittest
 from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
-from models import db
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop, fake_biblist
-from tests.base import MockEmailService, TestCaseDatabase
+from tests.base import MockEmailService, MockSolrBigqueryService,\
+    TestCaseDatabase
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -75,10 +73,11 @@ class TestDeletionEpic(TestCaseDatabase):
             self.assertEqual(response.status_code, 200, response)
 
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_dave.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
         self.assertTrue(len(response.json['documents']) == number_of_documents)
 
         # Dave does not want to manage who can change content. He wants Mary to
@@ -140,10 +139,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got removed
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_student.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_student.headers
+            )
         self.assertTrue(
             len(response.json['documents']) == number_of_documents/2.
         )
@@ -163,10 +163,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got added
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_student.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_student.headers
+            )
         self.assertTrue(
             len(response.json['documents']) == number_of_documents
         )

--- a/biblib/tests/functional_tests/test_big_share_editor_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_editor_epic.py
@@ -13,14 +13,12 @@ PROJECT_HOME = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../../'))
 sys.path.append(PROJECT_HOME)
 
-import app
-import json
 import unittest
 from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
-from models import db
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import MockEmailService, TestCaseDatabase
+from tests.base import MockEmailService, MockSolrBigqueryService,\
+    TestCaseDatabase
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -72,10 +70,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Checks they are all in the library
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_dave.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
         self.assertTrue(len(response.json['documents']) == number_of_documents)
 
         # Dave is too busy to do any work on the library and so asks his
@@ -104,10 +103,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Mary looks at the library
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json['documents']) == number_of_documents)
 
@@ -130,10 +130,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got removed
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
         self.assertTrue(
             len(response.json['documents']) == number_of_documents/2
         )
@@ -154,10 +155,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got added
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
         self.assertTrue(
             len(response.json['documents']) == number_of_documents
         )

--- a/biblib/tests/functional_tests/test_big_share_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_epic.py
@@ -17,7 +17,8 @@ import unittest
 from views import NO_PERMISSION_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import MockEmailService, TestCaseDatabase
+from tests.base import MockEmailService, MockSolrBigqueryService,\
+    TestCaseDatabase
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -83,20 +84,22 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Check they all got added
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_dave.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
         self.assertTrue(len(response.json['documents']) == number_of_documents)
 
         # Dave has made his library private, and his library friend Mary says
         # she cannot access the library.
         # Dave selects her e-mail address
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
 
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertNotIn('documents', response.json.keys())
@@ -116,10 +119,11 @@ class TestDeletionEpic(TestCaseDatabase):
         # Mary writes back to say she can see his libraries and is happy but
         # wants to add content herself
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(len(response.json['documents']) == number_of_documents)
 
@@ -148,10 +152,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Mary realises she can no longer read content
         url = url_for('libraryview', library=library_id_dave)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertNotIn('documents', response.json.keys())
         self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])

--- a/biblib/tests/functional_tests/test_job_epic.py
+++ b/biblib/tests/functional_tests/test_job_epic.py
@@ -16,7 +16,8 @@ sys.path.append(PROJECT_HOME)
 import unittest
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import TestCaseDatabase, MockEmailService
+from tests.base import TestCaseDatabase, MockEmailService, \
+    MockSolrBigqueryService
 
 class TestJobEpic(TestCaseDatabase):
     """
@@ -85,20 +86,22 @@ class TestJobEpic(TestCaseDatabase):
 
         # Checks that there are no documents in the library
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=user_mary.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
         self.assertTrue(len(response.json['documents']) == 0, response.json)
 
         # Happy with her library, she copies the link to the library and
         # e-mails it to the prospective employer.
 
         # She then asks a friend to check the link, and it works fine.
-        response = self.client.get(
-            url,
-            headers=user_random.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_random.headers
+            )
         self.assertEqual(response.status_code, 200)
 
 if __name__ == '__main__':

--- a/biblib/tests/functional_tests/test_job_fast_epic.py
+++ b/biblib/tests/functional_tests/test_job_fast_epic.py
@@ -17,7 +17,7 @@ import unittest
 from views import DUPLICATE_DOCUMENT_NAME_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import TestCaseDatabase
+from tests.base import TestCaseDatabase, MockSolrBigqueryService
 
 class TestJobEpic(TestCaseDatabase):
     """
@@ -60,10 +60,11 @@ class TestJobEpic(TestCaseDatabase):
 
         # She then asks a friend to check the link, and it works fine.
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=user_random.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_random.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json['documents']),
                          len(stub_library.bibcode))

--- a/biblib/tests/functional_tests/test_teacher_epic.py
+++ b/biblib/tests/functional_tests/test_teacher_epic.py
@@ -18,7 +18,8 @@ from views import NO_PERMISSION_ERROR
 
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import MockEmailService, TestCaseDatabase
+from tests.base import MockEmailService, MockSolrBigqueryService, \
+    TestCaseDatabase
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -57,10 +58,11 @@ class TestDeletionEpic(TestCaseDatabase):
         for user in [user_student_1, user_student_2]:
             # The students check they can see the content
             url = url_for('libraryview', library=library_id_teacher)
-            response = self.client.get(
-                url,
-                headers=user.headers
-            )
+            with MockSolrBigqueryService():
+                response = self.client.get(
+                    url,
+                    headers=user.headers
+                )
             self.assertEqual(
                 response.status_code,
                 NO_PERMISSION_ERROR['number']
@@ -84,10 +86,11 @@ class TestDeletionEpic(TestCaseDatabase):
 
             # The students check they can see the content
             url = url_for('libraryview', library=library_id_teacher)
-            response = self.client.get(
-                url,
-                headers=user.headers
-            )
+            with MockSolrBigqueryService():
+                response = self.client.get(
+                    url,
+                    headers=user.headers
+                )
             self.assertEqual(response.status_code, 200)
             self.assertIn('documents', response.json)
 
@@ -104,19 +107,21 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Student 2 cannot see the content
         url = url_for('libraryview', library=library_id_teacher)
-        response = self.client.get(
-            url,
-            headers=user_student_2.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_student_2.headers
+            )
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
 
         # Student 1 can see the content still
         url = url_for('libraryview', library=library_id_teacher)
-        response = self.client.get(
-            url,
-            headers=user_student_1.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_student_1.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn('documents', response.json)
 

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -18,7 +18,8 @@ from views import UserView, LibraryView, DocumentView, PermissionView, BaseView
 from views import DEFAULT_LIBRARY_DESCRIPTION
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from utils import BackendIntegrityError, PermissionDeniedError
-from tests.base import TestCaseDatabase, MockEmailService
+from tests.base import TestCaseDatabase, MockEmailService, \
+    MockSolrBigqueryService
 
 
 class TestBaseViews(TestCaseDatabase):
@@ -716,6 +717,42 @@ class TestLibraryViews(TestCaseDatabase):
             library_id=library.id
         )
         self.assertEqual(library.bibcode, response_library.bibcode)
+
+    def test_that_solr_data_is_returned(self):
+        """
+        Test that can retrieve all the bibcodes from a library with the data
+        returned from the solr bigquery end point
+
+        :return: no return
+        """
+
+        # Ensure a user exists
+        user = User(absolute_uid=self.stub_user.absolute_uid)
+        db.session.add(user)
+        db.session.commit()
+
+        # Ensure a library exists
+        library = Library(name='MyLibrary',
+                          description='My library',
+                          public=True,
+                          bibcode=self.stub_library.bibcode)
+
+        # Give the user and library permissions
+        permission = Permissions(read=True,
+                                 write=True)
+
+        # Commit the stub data
+        user.permissions.append(permission)
+        library.permissions.append(permission)
+        db.session.add_all([library, permission, user])
+        db.session.commit()
+
+        # Retrieve the bibcodes using the web services
+        with MockSolrBigqueryService():
+            response_library = self.library_view.solr_big_query(
+                bibcodes=library.bibcode
+            )
+        self.assertIn('solr', response_library)
 
     def test_user_without_permission_cannot_access_private_library(self):
         """

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -752,7 +752,7 @@ class TestLibraryViews(TestCaseDatabase):
             response_library = self.library_view.solr_big_query(
                 bibcodes=library.bibcode
             )
-        self.assertIn('solr', response_library)
+        self.assertIn('responseHeader', response_library.json())
 
     def test_user_without_permission_cannot_access_private_library(self):
         """

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -17,7 +17,8 @@ from views import DUPLICATE_LIBRARY_NAME_ERROR, MISSING_LIBRARY_ERROR, \
     DEFAULT_LIBRARY_DESCRIPTION, WRONG_TYPE_LIST_ERROR, \
     DUPLICATE_DOCUMENT_NAME_ERROR, API_MISSING_USER_EMAIL, API_MISSING_USER_UID
 from tests.stubdata.stub_data import LibraryShop, UserShop
-from tests.base import MockEmailService, TestCaseDatabase
+from tests.base import MockEmailService, MockSolrBigqueryService,\
+    TestCaseDatabase
 
 class TestWebservices(TestCaseDatabase):
     """
@@ -81,7 +82,8 @@ class TestWebservices(TestCaseDatabase):
         """
 
         url = url_for('libraryview', library='test')
-        response = self.client.get(url)
+        with MockSolrBigqueryService():
+            response = self.client.get(url)
 
         self.assertEqual(response.status_code,
                          MISSING_USERNAME_ERROR['number'])
@@ -190,10 +192,11 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library exists in the database
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user.headers
+            )
         self.assertEqual(response.status_code, 200)
 
         for document in response.json['documents']:
@@ -225,10 +228,11 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library exists in the database
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn('documents', response.json)
         self.assertIn('solr', response.json)
@@ -298,10 +302,11 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library was created and documents exist
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user.headers
+            )
 
         self.assertEqual(response.status_code, 200, response)
         self.assertEqual(stub_library.bibcode, response.json['documents'])
@@ -400,10 +405,11 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library is empty
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user.headers
+            )
         self.assertTrue(len(response.json['documents']) == 0,
                         response.json['documents'])
 
@@ -491,10 +497,11 @@ class TestWebservices(TestCaseDatabase):
 
         # Check there is no document content
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user.headers
+            )
         self.assertEqual(response.status_code,
                          MISSING_LIBRARY_ERROR['number'],
                          'Received response error: {0}'
@@ -545,10 +552,11 @@ class TestWebservices(TestCaseDatabase):
         # does not have the permissions
         # Check the library is empty
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user_2.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user_2.headers
+            )
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
 
@@ -603,10 +611,11 @@ class TestWebservices(TestCaseDatabase):
 
         # The user can now access the content of the library
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user_2.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user_2.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertTrue('documents' in response.json)
 
@@ -876,10 +885,11 @@ class TestWebservices(TestCaseDatabase):
         # Request from user 2
         # Given it is public, should be able to view it
         url = url_for('libraryview', library=library_id)
-        response = self.client.get(
-            url,
-            headers=stub_user_2.headers
-        )
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=stub_user_2.headers
+            )
         self.assertEqual(response.status_code, 200)
         self.assertIn('documents', response.json)
 

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -199,6 +199,40 @@ class TestWebservices(TestCaseDatabase):
         for document in response.json['documents']:
             self.assertIn(document, stub_library.bibcode)
 
+    def test_get_solr_data_for_documents(self):
+        """
+        Test the /libraries/<> route to check that solr data is returned by
+        the service
+
+        :return: no return
+        """
+
+        # Stub data
+        stub_user = UserShop()
+        stub_library = LibraryShop(want_bibcode=True)
+
+        # Make the library
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library.user_view_post_data_json,
+            headers=stub_user.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        library_id = response.json['id']
+        for key in ['name', 'id', 'bibcode', 'description']:
+            self.assertIn(key, response.json)
+
+        # Check the library exists in the database
+        url = url_for('libraryview', library=library_id)
+        response = self.client.get(
+            url,
+            headers=stub_user.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('documents', response.json)
+        self.assertIn('solr', response.json)
+
     def test_create_library_resource_and_add_bibcodes_of_wrong_type(self):
         """
         Test the /libraries route

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -4,6 +4,7 @@ Views
 
 import uuid
 import base64
+from StringIO import StringIO
 from flask import request, current_app
 from flask.ext.restful import Resource
 from flask.ext.discoverer import advertise
@@ -681,6 +682,32 @@ class LibraryView(BaseView):
                 return True
 
         return False
+
+    def solr_big_query(self, bibcodes):
+        """
+        A thin wrapper for the solr bigquery service.
+
+        :param bibcodes: list of bibcodes
+        :return: solr bigquery end point response
+        """
+
+        bibcodes.insert(0, 'bibcode')
+        bibcodes = '\n'.join(bibcodes)
+
+        params = {
+            'q': '*:*',
+            'fl': 'bibcode',
+            'fq': '{!bitset}',
+        }
+        current_app.logger.info('Obtaining UID of user: {0}, {1}'
+                                .format(params, bibcodes))
+        response = client().post(
+            url=current_app.config['BIBLIB_SOLR_BIG_QUERY_URL'],
+            params=params,
+            data=bibcodes
+        )
+
+        return response
 
     # Methods
     def get(self, library):

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -4,7 +4,7 @@ Views
 
 import uuid
 import base64
-from StringIO import StringIO
+import json
 from flask import request, current_app
 from flask.ext.restful import Resource
 from flask.ext.discoverer import advertise
@@ -691,15 +691,14 @@ class LibraryView(BaseView):
         :return: solr bigquery end point response
         """
 
-        bibcodes.insert(0, 'bibcode')
-        bibcodes = '\n'.join(bibcodes)
+        bibcodes = 'bibcode\n' + '\n'.join(bibcodes)
 
         params = {
             'q': '*:*',
+            'wt': 'json',
             'fl': 'bibcode',
-            'fq': '{!bitset}',
         }
-        current_app.logger.info('Obtaining UID of user: {0}, {1}'
+        current_app.logger.info('Querying Solr bigquery microservice: {0}, {1}'
                                 .format(params, bibcodes))
         response = client().post(
             url=current_app.config['BIBLIB_SOLR_BIG_QUERY_URL'],
@@ -760,19 +759,41 @@ class LibraryView(BaseView):
 
         # If the library is public, allow access
         try:
+            # Try to load the dictionary and obtain the solr content
             library = self.get_documents_from_library(library_id=library)
+            # pay attention to any functions that try to mutate the list
+            # this will alter expected returns later
             documents = library.bibcode
-            if library.public:
-                current_app.logger.info('Library: {0} is public'
-                                        .format(library.id))
-                return {'documents': documents}, 200
-            else:
-                current_app.logger.warning('Library: {0} is private'
-                                           .format(library.id))
 
-        except:
+            try:
+                solr = self.solr_big_query(bibcodes=documents).json()
+            except Exception as error:
+                current_app.logger.warning('Could not parse solr data: {0}'
+                                           .format(error))
+                solr = {'error': 'Could not parse solr data'}
+
+            # Make the response dictionary
+            response = dict(
+                documents=documents,
+                solr=solr
+            )
+
+        except Exception as error:
+            current_app.logger.warning(
+                'Library missing or solr endpoint failed: {0}'
+                .format(error)
+            )
             return {'error': MISSING_LIBRARY_ERROR['body']}, \
                 MISSING_LIBRARY_ERROR['number']
+
+        # Skip anymore logic if the library is public
+        if library.public:
+            current_app.logger.info('Library: {0} is public'
+                                    .format(library.id))
+            return response, 200
+        else:
+            current_app.logger.warning('Library: {0} is private'
+                                       .format(library.id))
 
         # If the user does not exist then there are no associated permissions
         # If the user exists, they will have permissions
@@ -803,7 +824,7 @@ class LibraryView(BaseView):
                                 'ALLOWED'
                                 .format(user, library.id))
 
-        return {'documents': documents}, 200
+        return response, 200
 
 
 class DocumentView(BaseView):


### PR DESCRIPTION
Addresses and closes issue #33 that required the returning of solr like data from the libraryview/<> GET end point. This returns the solr-like data with the tag 'solr'.

Mock service included for the solr end point. Currently, it only returns data that is similar to that of the end point. However, if there are issues in the future, something more realistic will have to be incorporated, but for now it is nice to have the scaffolding.
    
Tests laid out that require a solr like output in the form of functional tests, unit tests in the webservices, and a unit test in the views.
    
The configuration file was updated to include the end point of the solr service. The 'api' scope is required to access this end point. Consul has been updated appropriately.
