### PR TITLE
Feature, number of added/removed docs returned

### DIFF
--- a/biblib/tests/functional_tests/test_big_share_admin_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_admin_epic.py
@@ -70,6 +70,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=stub_library.document_view_post_data_json('add'),
                 headers=user_dave.headers
             )
+            self.assertEqual(response.json['number_added'],
+                             len(stub_library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
         url = url_for('libraryview', library=library_id_dave)
@@ -132,6 +134,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=libraries_added[i].document_view_post_data_json('remove'),
                 headers=user_student.headers
             )
+            self.assertEqual(response.json['number_removed'],
+                             len(libraries_added[i].bibcode))
             self.assertEqual(response.status_code, 200, response)
 
             libraries_removed.append(libraries_added[i])
@@ -158,6 +162,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=library.document_view_post_data_json('add'),
                 headers=user_mary.headers
             )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
             libraries_added.append(library)
 

--- a/biblib/tests/functional_tests/test_big_share_editor_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_editor_epic.py
@@ -64,6 +64,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=library.document_view_post_data_json('add'),
                 headers=user_dave.headers
             )
+            self.assertEqual(response.json['number_added'],
+                 len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
             libraries_added.append(library)
@@ -123,6 +125,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=libraries_added[i].document_view_post_data_json('remove'),
                 headers=user_mary.headers
             )
+            self.assertEqual(response.json['number_removed'],
+                             len(libraries_added[i].bibcode))
             self.assertEqual(response.status_code, 200, response)
 
             libraries_removed.append(libraries_added[i])
@@ -149,6 +153,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=library.document_view_post_data_json('add'),
                 headers=user_mary.headers
             )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
             libraries_added.append(library)

--- a/biblib/tests/functional_tests/test_big_share_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_epic.py
@@ -80,6 +80,8 @@ class TestDeletionEpic(TestCaseDatabase):
                 data=library.document_view_post_data_json('add'),
                 headers=user_dave.headers
             )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
         # Check they all got added

--- a/biblib/tests/functional_tests/test_job_epic.py
+++ b/biblib/tests/functional_tests/test_job_epic.py
@@ -72,6 +72,8 @@ class TestJobEpic(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('add'),
             headers=user_mary.headers
         )
+        self.assertEqual(response.json['number_added'],
+                         len(stub_library.bibcode))
         self.assertEqual(response.status_code, 200, response)
 
         # Mary realises she added one that is not hers and goes back to her
@@ -82,6 +84,8 @@ class TestJobEpic(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('remove'),
             headers=user_mary.headers
         )
+        self.assertEqual(response.json['number_removed'],
+                         len(stub_library.bibcode))
         self.assertEqual(response.status_code, 200, response)
 
         # Checks that there are no documents in the library

--- a/biblib/tests/functional_tests/test_returned_data_epic.py
+++ b/biblib/tests/functional_tests/test_returned_data_epic.py
@@ -85,6 +85,8 @@ class TestReturnedDataEpic(TestCaseDatabase):
                 data=library.document_view_post_data_json('add'),
                 headers=user_dave.headers
             )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
         # Dave looks in the library overview and sees that his library size
@@ -138,6 +140,8 @@ class TestReturnedDataEpic(TestCaseDatabase):
                 data=library.document_view_post_data_json('add'),
                 headers=user_mary.headers
             )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
         # Dave sees that the number of bibcodes has increased and that the

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -1059,10 +1059,11 @@ class TestDocumentViews(TestCaseDatabase):
         # Get stub data for the document
 
         # Add a document to the library
-        self.document_view.add_document_to_library(
+        number_added = self.document_view.add_document_to_library(
             library_id=library_id,
             document_data=self.stub_library.document_view_post_data('add')
         )
+        self.assertEqual(number_added, len(self.stub_library.bibcode))
 
         # Check that the document is in the library
         library = Library.query.filter(Library.id == library_id).all()
@@ -1070,10 +1071,11 @@ class TestDocumentViews(TestCaseDatabase):
             self.assertIn(self.stub_library.bibcode[0], _lib.bibcode)
 
         # Add a different document to the library
-        self.document_view.add_document_to_library(
+        number_added = self.document_view.add_document_to_library(
             library_id=library_id,
             document_data=self.stub_library_2.document_view_post_data('add')
         )
+        self.assertEqual(number_added, len(self.stub_library.bibcode))
 
         # Check that the document is in the library
         library = Library.query.filter(Library.id == library_id).all()
@@ -1112,10 +1114,11 @@ class TestDocumentViews(TestCaseDatabase):
         # Get stub data for the document
 
         # Add a document to the library
-        self.document_view.add_document_to_library(
+        number_added = self.document_view.add_document_to_library(
             library_id=library_id,
             document_data=self.stub_library.document_view_post_data('add')
         )
+        self.assertEqual(number_added, len(self.stub_library.bibcode))
 
         with self.assertRaises(BackendIntegrityError):
             self.document_view.add_document_to_library(
@@ -1152,10 +1155,11 @@ class TestDocumentViews(TestCaseDatabase):
         db.session.commit()
 
         # Remove the bibcode from the library
-        self.document_view.remove_documents_from_library(
+        number_removed = self.document_view.remove_documents_from_library(
             library_id=library.id,
             document_data=self.stub_library.document_view_post_data('remove')
         )
+        self.assertEqual(number_removed, len(self.stub_library.bibcode))
 
         # Check it worked
         library = Library.query.filter(Library.id == library.id).one()

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -294,11 +294,14 @@ class TestWebservices(TestCaseDatabase):
 
         # Add to the library
         url = url_for('documentview', library=library_id)
-        self.client.post(
+        response = self.client.post(
             url,
             data=stub_library.document_view_post_data_json('add'),
             headers=stub_user.headers
         )
+        self.assertEqual(response.json['number_added'],
+                         len(stub_library.bibcode))
+        self.assertEqual(response.status_code, 200)
 
         # Check the library was created and documents exist
         url = url_for('libraryview', library=library_id)
@@ -345,6 +348,8 @@ class TestWebservices(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('add'),
             headers=stub_user.headers
         )
+        self.assertEqual(response.json['number_added'],
+                         len(stub_library.bibcode))
         self.assertEqual(response.status_code, 200)
 
         # Should not be able to add the same document
@@ -392,7 +397,9 @@ class TestWebservices(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('add'),
             headers=stub_user.headers
         )
-        self.assertTrue(response.status, 200)
+        self.assertEqual(response.json['number_added'],
+                         len(stub_library.bibcode))
+        self.assertEqual(response.status_code, 200)
 
         # Delete the document
         url = url_for('documentview', library=library_id)
@@ -401,7 +408,9 @@ class TestWebservices(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('remove'),
             headers=stub_user.headers
         )
-        self.assertTrue(response.status, 200)
+        self.assertEqual(response.json['number_removed'],
+                         len(stub_library.bibcode))
+        self.assertEqual(response.status_code, 200)
 
         # Check the library is empty
         url = url_for('libraryview', library=library_id)
@@ -854,6 +863,8 @@ class TestWebservices(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('add'),
             headers=stub_user_1.headers
         )
+        self.assertEqual(response.json['number_added'],
+                                       len(stub_library.bibcode))
         self.assertEqual(response.status_code, 200)
 
     def test_anonymous_users_can_access_public_libraries(self):


### PR DESCRIPTION
The number of documents that are added or removed using the libraries/<>
end point with the POST method, are returned to the user with the json
keys 'number_added' or 'number_removed', depending if you used the action
'add' or 'remove', respectively.

Relevant tests have been udpated to include this in the response.