### PR TITLE
Feature/add duplicate docs

### DIFF
--- a/biblib/models.py
+++ b/biblib/models.py
@@ -154,6 +154,17 @@ class MutableList(Mutable, list):
         for item in value:
             self.remove(item)
 
+    def upsert(self, value):
+        """
+        Add values that do not exist in the current list
+        :param value:
+        :return:
+        """
+        value = list(set(value))
+        value = [item for item in value if item not in list(self)]
+
+        self.extend(value)
+
     @classmethod
     def coerce(cls, key, value):
         """
@@ -203,7 +214,7 @@ class Library(db.Model):
     name = db.Column(db.String(50))
     description = db.Column(db.String(50))
     public = db.Column(db.Boolean)
-    bibcode = db.Column(MutableList.as_mutable(ARRAY(db.String(50))))
+    bibcode = db.Column(MutableList.as_mutable(ARRAY(db.String(50))), default=[])
     date_created = db.Column(
         db.DateTime,
         nullable=False,

--- a/biblib/tests/functional_tests/test_job_fast_epic.py
+++ b/biblib/tests/functional_tests/test_job_fast_epic.py
@@ -14,7 +14,6 @@ PROJECT_HOME = os.path.abspath(
 sys.path.append(PROJECT_HOME)
 
 import unittest
-from views import DUPLICATE_DOCUMENT_NAME_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from tests.base import TestCaseDatabase, MockSolrBigqueryService
@@ -77,10 +76,8 @@ class TestJobEpic(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('add'),
             headers=user_mary.headers
         )
-        self.assertEqual(response.status_code,
-                         DUPLICATE_DOCUMENT_NAME_ERROR['number'])
-        self.assertEqual(response.json['error'],
-                         DUPLICATE_DOCUMENT_NAME_ERROR['body'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['number_added'], 0)
 
 
 if __name__ == '__main__':

--- a/biblib/tests/unit_tests/test_models.py
+++ b/biblib/tests/unit_tests/test_models.py
@@ -77,7 +77,30 @@ class TestModelTypes(TestCase):
 
         self.assertEqual([], mutable_list)
 
+    def test_upsert_of_mutable_list(self):
+        """
+        Checks that the custom upsert command works as expected
+
+        :return: no return
+        """
+
+        input_list_1 = [1, 2, 3]
+        input_list_2 = [2, 2, 3, 4, 4]
+        expected_output = [1, 2, 3, 4]
+
+        mutable_list = MutableList()
+        mutable_list.extend(input_list_1)
+        mutable_list.upsert(input_list_2)
+
+        self.assertEqual(mutable_list, expected_output)
+
+
     def test_coerce(self):
+        """
+        Checks the coerce for SQLAlchemy works correctly
+
+        :return: no return
+        """
 
         mutable_list = MutableList()
 

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -205,7 +205,7 @@ class TestUserViews(TestCaseDatabase):
             library_data=self.stub_library.user_view_post_data
         )
 
-        self.assertIsNone(library.bibcode)
+        self.assertEqual([], library.bibcode)
 
         # Check that the library was created with the correct permissions
         result = Permissions.query\

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -1120,11 +1120,12 @@ class TestDocumentViews(TestCaseDatabase):
         )
         self.assertEqual(number_added, len(self.stub_library.bibcode))
 
-        with self.assertRaises(BackendIntegrityError):
-            self.document_view.add_document_to_library(
-                library_id=library_id,
-                document_data=self.stub_library.document_view_post_data('add')
-            )
+        # Shouldn't add the same document again
+        number_added = self.document_view.add_document_to_library(
+            library_id=library_id,
+            document_data=self.stub_library.document_view_post_data('add')
+        )
+        self.assertEqual(0, number_added)
 
     def test_user_can_remove_document_from_library(self):
         """

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -15,7 +15,7 @@ from flask import url_for
 from views import DUPLICATE_LIBRARY_NAME_ERROR, MISSING_LIBRARY_ERROR, \
     MISSING_USERNAME_ERROR, NO_PERMISSION_ERROR, DEFAULT_LIBRARY_NAME_PREFIX, \
     DEFAULT_LIBRARY_DESCRIPTION, WRONG_TYPE_LIST_ERROR, \
-    DUPLICATE_DOCUMENT_NAME_ERROR, API_MISSING_USER_EMAIL
+    API_MISSING_USER_EMAIL
 from tests.stubdata.stub_data import LibraryShop, UserShop
 from tests.base import MockEmailService, MockSolrBigqueryService,\
     TestCaseDatabase
@@ -359,10 +359,8 @@ class TestWebservices(TestCaseDatabase):
             data=stub_library.document_view_post_data_json('add'),
             headers=stub_user.headers
         )
-        self.assertEqual(response.status_code,
-                         DUPLICATE_DOCUMENT_NAME_ERROR['number'])
-        self.assertEqual(response.json['error'],
-                         DUPLICATE_DOCUMENT_NAME_ERROR['body'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['number_added'], 0)
 
     def test_remove_document_from_library(self):
         """

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -899,23 +899,8 @@ class DocumentView(BaseView):
         # Find the specified library
         library = Library.query.filter(Library.id == library_id).one()
 
-        # Ensure unique content
-        _bibcodes = list(set(document_data['bibcode']))
-
-        if not library.bibcode:
-            start_length = 0
-            current_app.logger.debug('Zero length array: {0}'
-                                     .format(library.bibcode))
-            library.bibcode = _bibcodes
-        else:
-            start_length = len(library.bibcode)
-            _bibcodes = [_bibcode for _bibcode in _bibcodes
-                         if _bibcode not in library.bibcode]
-
-            current_app.logger.debug('Non-Zero length array: {0}'
-                                     .format(library.bibcode))
-            if _bibcodes:
-                library.bibcode.extend(_bibcodes)
+        start_length = len(library.bibcode)
+        library.bibcode.upsert(document_data['bibcode'])
 
         db.session.add(library)
         db.session.commit()


### PR DESCRIPTION
When adding documents it will no longer fail if you pass duplicate bibcodes. Instead, there is now an upsert command for the bibcode type, which adds the non-duplicated-, unique-values.
    
The number of added documents will be 0 if nothing is added.