### PR TITLE
Issue #31 addresses and closes the issue

### DIFF
--- a/biblib/app.py
+++ b/biblib/app.py
@@ -51,7 +51,7 @@ def create_app(config_type='STAGING'):
 
     api.add_resource(PermissionView,
                      '/permissions/<string:library>',
-                     methods=['POST'])
+                     methods=['GET', 'POST'])
 
     return app
 


### PR DESCRIPTION
A GET end point has been added to the PermissionView view. This
returns a list of user emails with the permissions associated
to them.

The end point is permissions/<library_slug>

Only the users with 'owner' or 'admin' can get the list of permissions
for a given library.

Relevant tests have been added and updated to check that only the
admin and owner users can gain access to this list. And that the content
of the list returns is what is expected.

The only missing feature is to tidy up the *_access() methods that
would be nice to put as @classmethods that accesses a class attribute
that describes the level for that view.