### PR TITLE
Feature/issue#47/transfer library ownership

### DIFF
--- a/biblib/app.py
+++ b/biblib/app.py
@@ -3,7 +3,8 @@ Application
 """
 
 import logging.config
-from views import UserView, LibraryView, DocumentView, PermissionView
+from views import UserView, LibraryView, DocumentView, PermissionView, \
+    TransferView
 from models import db
 
 from flask import Flask
@@ -52,6 +53,10 @@ def create_app(config_type='STAGING'):
     api.add_resource(PermissionView,
                      '/permissions/<string:library>',
                      methods=['GET', 'POST'])
+
+    api.add_resource(TransferView,
+                     '/transfer/<string:library>',
+                     methods=['POST'])
 
     return app
 

--- a/biblib/tests/functional_tests/test_retiring_librarian.py
+++ b/biblib/tests/functional_tests/test_retiring_librarian.py
@@ -1,0 +1,145 @@
+"""
+Functional test
+
+Retiring Librarian Epic
+
+Storyboard is defined within the comments of the program itself
+"""
+
+import sys
+import os
+
+PROJECT_HOME = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../'))
+sys.path.append(PROJECT_HOME)
+
+import unittest
+from views import NO_PERMISSION_ERROR, API_MISSING_USER_EMAIL
+from flask import url_for
+from tests.stubdata.stub_data import UserShop, LibraryShop
+from tests.base import MockEmailService, MockSolrBigqueryService,\
+    TestCaseDatabase, MockEndPoint
+
+
+class TestRetiringLibrarianEpic(TestCaseDatabase):
+    """
+    Base class used to test the Retiring Librarian Epic
+    """
+
+    def test_retiring_librarian_epic(self):
+        """
+        Carries out the epic 'Retiring Librarian', where a user that owns and
+        maintains a library wants to pass on the responsibility to someone else
+
+        :return: no return
+        """
+
+        # Stub data
+        user_dave = UserShop()
+        user_mary = UserShop()
+
+        stub_library = LibraryShop()
+
+        # Dave has a big library that he has maintained for many years
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library.user_view_post_data_json,
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200, response)
+        library_id_dave = response.json['id']
+
+        # Dave adds content to his library
+        number_of_documents = 20
+        for i in range(number_of_documents):
+
+            # Stub data
+            library = LibraryShop()
+
+            # Add document
+            url = url_for('documentview', library=library_id_dave)
+            response = self.client.post(
+                url,
+                data=library.document_view_post_data_json('add'),
+                headers=user_dave.headers
+            )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
+            self.assertEqual(response.status_code, 200, response)
+
+        # Check they all got added
+        url = url_for('libraryview', library=library_id_dave)
+        with MockSolrBigqueryService():
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
+        self.assertTrue(len(response.json['documents']) == number_of_documents)
+
+        # Dave is soon retiring and wants to give the permissions to the
+        # person who takes over his job.
+        # Unfortunately, the first time he tries, he realises she has not made
+        # an ADS account
+        url = url_for('transferview', library=library_id_dave)
+        user_mary.name = 'fail'
+        with MockEmailService(user_mary):
+            response = self.client.post(
+                url,
+                headers=user_dave.headers,
+                data=user_mary.transfer_view_post_data_json()
+            )
+        self.assertEqual(response.status_code,
+                         API_MISSING_USER_EMAIL['number'])
+        self.assertEqual(response.json['error'],
+                         API_MISSING_USER_EMAIL['body'])
+
+        # Mary makes an account and tries to transfer Dave's library herself
+        # because Dave is busy
+        url = url_for('transferview', library=library_id_dave)
+        user_mary.name = 'Mary'
+        with MockEmailService(user_mary):
+            response = self.client.post(
+                url,
+                headers=user_mary.headers,
+                data=user_mary.transfer_view_post_data_json()
+            )
+        self.assertEqual(response.status_code,
+                         NO_PERMISSION_ERROR['number'])
+        self.assertEqual(response.json['error'],
+                         NO_PERMISSION_ERROR['body'])
+
+        # Dave finds out she has an account and then tells her he will transfer
+        # the library because she does not have permissions
+        url = url_for('transferview', library=library_id_dave)
+        with MockEmailService(user_mary):
+            response = self.client.post(
+                url,
+                headers=user_dave.headers,
+                data=user_mary.transfer_view_post_data_json()
+            )
+        self.assertEqual(response.status_code, 200)
+
+        # Dave checks he does not have access anymore
+        with MockEndPoint([user_mary, user_dave]):
+            url = url_for('permissionview', library=library_id_dave)
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
+        self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
+        self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
+
+        # Mary sees she does infact now have ownership
+        with MockEndPoint([user_mary, user_dave]):
+            url = url_for('permissionview', library=library_id_dave)
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(len(response.json) == 1)
+        self.assertEqual(['owner'], response.json[0][user_mary.email])
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -153,6 +153,24 @@ class UserShop(object):
         post_data = self.permission_view_post_data(permission, value)
         return json.dumps(post_data)
 
+    def transfer_view_post_data(self):
+        """
+        Expected data to be sent in a POST request to the TransferView.
+        :return: POST data in dictionary format
+        """
+        post_data = dict(
+            email=self.email
+        )
+        return post_data
+
+    def transfer_view_post_data_json(self):
+        """
+        Expected data to be sent in a POST request to the TransferView.
+        :return: POST data in JSON format
+        """
+        post_data = self.transfer_view_post_data()
+        return json.dumps(post_data)
+
 class LibraryShop(object):
     """
     A thin wrapper class that utilises the UserFactory to create extra stub

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -1066,8 +1066,6 @@ class DocumentView(BaseView):
           - admin
           - write
         """
-        # TODO: Want a tidier try/except/return pattern
-
         # Get the user requesting this from the header
         try:
             user_editing = self.helper_get_user_id()
@@ -1149,12 +1147,12 @@ class DocumentView(BaseView):
 
         Permissions:
         -----------
-        The following type of user can update a library:
+        The following type of user can update the 'name', 'library', and
+        'public':
+
           - owner
           - admin
         """
-        # TODO: see above, there is DRY here!
-
         try:
             user = self.helper_get_user_id()
         except KeyError:
@@ -1234,7 +1232,6 @@ class DocumentView(BaseView):
         The following type of user can update a library:
           - owner
         """
-
         try:
             user = self.helper_get_user_id()
         except KeyError:
@@ -1683,4 +1680,201 @@ class PermissionView(BaseView):
             return err(NO_PERMISSION_ERROR)
 
         current_app.logger.info('...SUCCESS.')
+        return {}, 200
+
+class TransferView(BaseView):
+    """
+    End point to manipulate the permissions between a user and a library
+    """
+    # TODO: Users that do not have an account, cannot be added to permissions
+    # TODO:   - send invitation?
+    # TODO: pass user and permissions as lists
+
+    decorators = [advertise('scopes', 'rate_limit')]
+    scopes = []
+    rate_limit = [1000, 60*60*24]
+
+    # Some permissions for this View
+    write_allowed = ['owner']
+
+    @classmethod
+    def write_access(cls, service_uid, library_id):
+        """
+        Defines which type of user has write permissions to a library.
+
+        :param service_uid: the user ID within this microservice
+        :param library_id: the unique ID of the library
+
+        :return: boolean, access (True), no access (False)
+        """
+
+        for access_type in cls.write_allowed:
+            if cls.helper_access_allowed(service_uid=service_uid,
+                                         library_id=library_id,
+                                         access_type=access_type):
+                return True
+
+        return False
+
+    @staticmethod
+    def transfer_ownership(current_owner_uid, new_owner_uid, library_id):
+        """
+        Transfers the ownership of a library from the current owner to the
+        new owner. The previous owner has all permissions for that library
+        removed.
+
+        :param current_owner_uid: the user ID within this microservice
+        :param new_owner_uid: the user ID within this microservice
+        :param library_id: the unique ID of the library
+
+        :return: no return
+        """
+
+        # Find the current permissions of the user
+        current_app.logger.info('User {0} has requested to transfer ownership '
+                                'of library {1} to user {2}'
+                                .format(current_owner_uid,
+                                        library_id,
+                                        new_owner_uid))
+
+        current_permission = Permissions.query.filter(
+            Permissions.user_id == current_owner_uid
+        ).filter(
+            Permissions.library_id == library_id
+        ).one()
+
+        # Try to get the current user's permissions
+        try:
+            # User already has permissions associated with it
+            new_permission = Permissions.query.filter(
+                Permissions.user_id == new_owner_uid
+            ).filter(
+                Permissions.library_id == library_id
+            ).one()
+
+            current_app.logger.info('User: {0} already has permissions for '
+                                    'library {1}: {2}'
+                                    .format(current_owner_uid,
+                                            library_id,
+                                            new_permission))
+
+            new_permission.owner = True
+
+        except NoResultFound:
+            # User does not have a permission with the library
+            current_app.logger.info('User {0} does not have permissions, for '
+                                    'library {1} creating fresh ones.'
+                                    .format(new_owner_uid, library_id))
+
+            new_permission = Permissions(user_id=new_owner_uid,
+                                         library_id=library_id,
+                                         owner=True)
+
+        db.session.delete(current_permission)
+        db.session.add(new_permission)
+        db.session.commit()
+
+        current_app.logger.info(
+            'Library {0} had ownership transferred '
+            'from user: {1} to user: {2}'
+            .format(library_id,
+                    current_owner_uid,
+                    new_owner_uid)
+        )
+
+    def post(self, library):
+        """
+        HTTP POST request that transfers the ownership of a library from user
+        to another
+        :param library: library ID
+
+        :return: the response for if the library was successfully transfered
+
+        Header:
+        -------
+        Must contain the API forwarded user ID of the user accessing the end
+        point
+
+        Post body:
+        ----------
+        KEYWORD, VALUE
+
+        transfer_user:   <e-mail>   e-mail of the user the account should be
+                                    transfered to
+
+        Return data:
+        -----------
+        No return data
+
+        Permissions:
+        -----------
+        The following type of user can transfer libraries:
+          - owner
+        """
+        # TODO: DRY of read_access, write_access, re-write them as classmethods
+
+        # Get the user requesting this from the header
+        try:
+            current_owner_api = self.helper_get_user_id()
+        except KeyError:
+            return err(MISSING_USERNAME_ERROR)
+
+        # URL safe base64 string to UUID
+        library = self.helper_slug_to_uuid(library)
+
+        # Get the internal service user UID
+        current_owner_service_uid = self.helper_absolute_uid_to_service_uid(
+            absolute_uid=current_owner_api
+        )
+
+        # Check the post data
+        try:
+            transfer_data = get_post_data(
+                request,
+                types=dict(
+                    email=unicode
+                )
+            )
+        except TypeError as error:
+            current_app.logger.error('Wrong type passed for POST: {0} [{1}]'
+                                     .format(request.data, error))
+            return err(WRONG_TYPE_ERROR)
+
+        # Look up the user in the API database
+        try:
+            new_owner_api = self.helper_email_to_api_uid(transfer_data)
+            current_app.logger.info('User: {0} corresponds to: {1}'
+                                    .format(transfer_data['email'],
+                                            new_owner_api))
+        except NoResultFound:
+            current_app.logger.error('User: {0} not found in the API database'
+                                     .format(transfer_data['email']))
+            return err(API_MISSING_USER_EMAIL)
+
+        # Convert api user ID to service ID
+        new_owner_service_uid = self.helper_absolute_uid_to_service_uid(
+            absolute_uid=new_owner_api
+        )
+        current_app.logger.info('User: {0} is internally: {1}'
+                                .format(new_owner_api, new_owner_service_uid))
+        # Check permissions
+        if not self.write_access(service_uid=current_owner_service_uid,
+                                 library_id=library):
+            current_app.logger.error(
+                'User {0} has the wrong permissions to transfer the ownership'
+                ' for library {1}'
+                .format(current_owner_service_uid, library)
+            )
+            return err(NO_PERMISSION_ERROR)
+
+        current_app.logger.info('User: {0} has permissions to transfer '
+                                'library {1} to the user {2}. Attempting '
+                                'transfer...'.format(current_owner_service_uid,
+                                                     library,
+                                                     new_owner_service_uid))
+
+        self.transfer_ownership(current_owner_uid=current_owner_service_uid,
+                                new_owner_uid=new_owner_service_uid,
+                                library_id=library)
+
         return {}, 200


### PR DESCRIPTION
A new end point called transfer and accessible by '/transfer/<library_id>' has been included. The e-mail of the user who is the new owner is passed in the post data.

Only the owner can request to transfer the ownership of the library. Relevant unit tests have been added.

The owner afterwards has no permissions at all.

If the user already has permissions, ownership will be added as well, which should override all others.