### PR TITLE
Addresses and closes issue #70

### DIFF
--- a/biblib/tests/functional_tests/test_anonymous_epic.py
+++ b/biblib/tests/functional_tests/test_anonymous_epic.py
@@ -17,7 +17,7 @@ import unittest
 from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import TestCaseDatabase, MockSolrBigqueryService
+from tests.base import TestCaseDatabase, MockSolrBigqueryService, MockEndPoint
 
 class TestAnonymousEpic(TestCaseDatabase):
     """
@@ -63,7 +63,8 @@ class TestAnonymousEpic(TestCaseDatabase):
 
         # Anonymous user tries to access the private library. But cannot.
         url = url_for('libraryview', library=library_id_private)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_anonymous]) as EP:
             response = self.client.get(
                 url,
                 headers=user_anonymous.headers
@@ -73,7 +74,8 @@ class TestAnonymousEpic(TestCaseDatabase):
 
         # Anonymous user tries to access the public library. And can.
         url = url_for('libraryview', library=library_id_public)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_anonymous]) as EP:
             response = self.client.get(
                 url,
                 headers=user_anonymous.headers

--- a/biblib/tests/functional_tests/test_big_share_admin_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_admin_epic.py
@@ -18,7 +18,7 @@ from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop, fake_biblist
 from tests.base import MockEmailService, MockSolrBigqueryService,\
-    TestCaseDatabase
+    TestCaseDatabase, MockEndPoint
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -75,7 +75,7 @@ class TestDeletionEpic(TestCaseDatabase):
             self.assertEqual(response.status_code, 200, response)
 
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -143,7 +143,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got removed
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_student, user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_student.headers
@@ -169,7 +170,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_student]) as EP:
             response = self.client.get(
                 url,
                 headers=user_student.headers

--- a/biblib/tests/functional_tests/test_big_share_editor_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_editor_epic.py
@@ -18,7 +18,7 @@ from views import USER_ID_KEYWORD, NO_PERMISSION_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from tests.base import MockEmailService, MockSolrBigqueryService,\
-    TestCaseDatabase
+    TestCaseDatabase, MockEndPoint
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -72,7 +72,7 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Checks they are all in the library
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -105,7 +105,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Mary looks at the library
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers
@@ -134,7 +135,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got removed
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers
@@ -161,7 +163,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # She checks that they got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers

--- a/biblib/tests/functional_tests/test_big_share_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_epic.py
@@ -86,7 +86,7 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Check they all got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -97,7 +97,8 @@ class TestDeletionEpic(TestCaseDatabase):
         # she cannot access the library.
         # Dave selects her e-mail address
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers
@@ -146,7 +147,8 @@ class TestDeletionEpic(TestCaseDatabase):
         # say she can see his libraries and is happy but wants to add content
         # herself
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers
@@ -179,7 +181,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Mary realises she can no longer read content
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers

--- a/biblib/tests/functional_tests/test_job_epic.py
+++ b/biblib/tests/functional_tests/test_job_epic.py
@@ -17,7 +17,7 @@ import unittest
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from tests.base import TestCaseDatabase, MockEmailService, \
-    MockSolrBigqueryService
+    MockSolrBigqueryService, MockEndPoint
 
 class TestJobEpic(TestCaseDatabase):
     """
@@ -90,7 +90,7 @@ class TestJobEpic(TestCaseDatabase):
 
         # Checks that there are no documents in the library
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers
@@ -101,7 +101,8 @@ class TestJobEpic(TestCaseDatabase):
         # e-mails it to the prospective employer.
 
         # She then asks a friend to check the link, and it works fine.
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([user_mary, user_random]) as EP:
             response = self.client.get(
                 url,
                 headers=user_random.headers

--- a/biblib/tests/functional_tests/test_job_fast_epic.py
+++ b/biblib/tests/functional_tests/test_job_fast_epic.py
@@ -16,7 +16,7 @@ sys.path.append(PROJECT_HOME)
 import unittest
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import TestCaseDatabase, MockSolrBigqueryService
+from tests.base import TestCaseDatabase, MockSolrBigqueryService, MockEndPoint
 
 class TestJobEpic(TestCaseDatabase):
     """
@@ -59,7 +59,7 @@ class TestJobEpic(TestCaseDatabase):
 
         # She then asks a friend to check the link, and it works fine.
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_random.headers

--- a/biblib/tests/functional_tests/test_retiring_librarian.py
+++ b/biblib/tests/functional_tests/test_retiring_librarian.py
@@ -70,7 +70,7 @@ class TestRetiringLibrarianEpic(TestCaseDatabase):
 
         # Check they all got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers

--- a/biblib/tests/functional_tests/test_returned_data_epic.py
+++ b/biblib/tests/functional_tests/test_returned_data_epic.py
@@ -196,7 +196,7 @@ class TestReturnedDataEpic(TestCaseDatabase):
                                   date_last_modified_2,
                                   delta=timedelta(seconds=1))
 
-    def test_returned_data_user_view_epic(self):
+    def test_returned_data_library_view_epic(self):
         """
         Carries out the epic 'Returned Data', for the LibraryView GET end point
         that should return content similar to the UserView GET end point. This

--- a/biblib/tests/functional_tests/test_returned_data_epic.py
+++ b/biblib/tests/functional_tests/test_returned_data_epic.py
@@ -18,7 +18,8 @@ import unittest
 from datetime import datetime, timedelta
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import MockEmailService, TestCaseDatabase
+from tests.base import MockEmailService, TestCaseDatabase, \
+    MockSolrBigqueryService, MockEndPoint
 
 
 class TestReturnedDataEpic(TestCaseDatabase):
@@ -194,6 +195,188 @@ class TestReturnedDataEpic(TestCaseDatabase):
         self.assertNotAlmostEqual(date_created_2,
                                   date_last_modified_2,
                                   delta=timedelta(seconds=1))
+
+    def test_returned_data_user_view_epic(self):
+        """
+        Carries out the epic 'Returned Data', for the LibraryView GET end point
+        that should return content similar to the UserView GET end point. This
+        ensures the responses are as expected.
+
+        :return: no return
+        """
+
+        # Stub data
+        user_dave = UserShop()
+        user_mary = UserShop()
+
+        stub_library = LibraryShop()
+
+        # Librarian Dave makes a library (no bibcodes)
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library.user_view_post_data_json,
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200, response)
+        library_id_dave = response.json['id']
+
+        # Dave looks at the library from the user view page and checks some
+        # of the parameters displayed to him.
+        with MockSolrBigqueryService(canonical_bibcode=stub_library.bibcode) \
+                as BQ, MockEndPoint([user_dave]) as EP:
+            url = url_for('libraryview', library=library_id_dave)
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
+
+        for key in ['documents', 'solr', 'metadata']:
+            self.assertIn(key, response.json)
+
+        documents = response.json['documents']
+        solr = response.json['solr']
+        metadata = response.json['metadata']
+        self.assertTrue(metadata['num_documents'] == 0)
+        self.assertTrue(metadata['num_users'] == 1)
+        self.assertTrue(metadata['permission'] == 'owner')
+        self.assertEqual(metadata['public'], False)
+        self.assertEqual(metadata['owner'], user_dave.email.split('@')[0])
+        date_created = datetime.strptime(metadata['date_created'],
+                                         '%Y-%m-%dT%H:%M:%S.%f')
+        date_last_modified = datetime.strptime(metadata['date_last_modified'],
+                                               '%Y-%m-%dT%H:%M:%S.%f')
+        self.assertAlmostEqual(date_created,
+                               date_last_modified,
+                               delta=timedelta(seconds=1))
+
+        # Dave adds content to his library
+        number_of_documents = 20
+        for i in range(number_of_documents):
+
+            # Stub data
+            library = LibraryShop()
+
+            # Add document
+            url = url_for('documentview', library=library_id_dave)
+            response = self.client.post(
+                url,
+                data=library.document_view_post_data_json('add'),
+                headers=user_dave.headers
+            )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
+            self.assertEqual(response.status_code, 200, response)
+
+            documents.append(library.bibcode[0])
+
+        # Dave looks in the library overview and sees that his library size
+        # has increased
+        url = url_for('libraryview', library=library_id_dave)
+        with MockSolrBigqueryService(canonical_bibcode=documents) as BQ, \
+                MockEndPoint([user_dave]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.json['metadata']['num_documents'] == number_of_documents
+        )
+
+        # Dave adds mary so that she can see the library and add content
+        url = url_for('permissionview', library=library_id_dave)
+        with MockEmailService(user_mary):
+            response = self.client.post(
+                url,
+                data=user_mary.permission_view_post_data_json('admin', True),
+                headers=user_dave.headers
+            )
+        self.assertEqual(response.status_code, 200)
+
+        # Mary sees that the number of users of the library has increased by 1
+        url = url_for('libraryview', library=library_id_dave)
+        with MockSolrBigqueryService(canonical_bibcode=documents) as BQ,\
+                MockEndPoint([user_mary, user_dave]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+        self.assertEqual(response.status_code, 200)
+        library = response.json['metadata']
+        self.assertTrue(library['num_users'] == 2)
+        self.assertTrue(library['permission'] == 'admin')
+
+        # Mary adds content to the library
+        number_of_documents_second = 1
+        for i in range(number_of_documents_second):
+
+            # Stub data
+            library = LibraryShop()
+
+            # Add document
+            url = url_for('documentview', library=library_id_dave)
+            response = self.client.post(
+                url,
+                data=library.document_view_post_data_json('add'),
+                headers=user_mary.headers
+            )
+            self.assertEqual(response.json['number_added'],
+                             len(library.bibcode))
+            self.assertEqual(response.status_code, 200, response)
+            documents.append(library.bibcode[0])
+
+        # Dave sees that the number of bibcodes has increased and that the
+        # last modified date has changed, but the created date has not
+        url = url_for('libraryview', library=library_id_dave)
+        with MockSolrBigqueryService(canonical_bibcode=documents) as BQ, \
+                MockEndPoint([user_dave, user_mary]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.json['metadata']['num_documents']
+            == (number_of_documents+number_of_documents_second)
+        )
+
+        # This is to artificial alter the update time
+        time.sleep(1)
+
+        # Dave makes the library public.
+        url = url_for('documentview', library=library_id_dave)
+        response = self.client.put(
+            url,
+            data=library.document_view_put_data_json(public=True),
+            headers=user_dave.headers
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Dave sees that the lock sign from his library page has dissapeared
+        url = url_for('libraryview', library=library_id_dave)
+        with MockSolrBigqueryService(canonical_bibcode=documents) as BQ,\
+                MockEndPoint([user_dave, user_mary]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_dave.headers
+            )
+
+        libraries = response.json['metadata']
+        self.assertTrue(
+            libraries['num_documents'] == number_of_documents+1
+        )
+        self.assertTrue(libraries['public'])
+        date_created_2 = datetime.strptime(libraries['date_created'],
+                                           '%Y-%m-%dT%H:%M:%S.%f')
+        date_last_modified_2 = \
+            datetime.strptime(libraries['date_last_modified'],
+                              '%Y-%m-%dT%H:%M:%S.%f')
+        self.assertEqual(date_created, date_created_2)
+        self.assertNotAlmostEqual(date_created_2,
+                                  date_last_modified_2,
+                                  delta=timedelta(seconds=1))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/biblib/tests/functional_tests/test_returned_solr_data_epic.py
+++ b/biblib/tests/functional_tests/test_returned_solr_data_epic.py
@@ -18,7 +18,7 @@ import unittest
 from datetime import datetime, timedelta
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
-from tests.base import MockSolrBigqueryService, TestCaseDatabase
+from tests.base import MockSolrBigqueryService, TestCaseDatabase, MockEndPoint
 
 
 class TestReturnedSolrDataEpic(TestCaseDatabase):
@@ -54,7 +54,7 @@ class TestReturnedSolrDataEpic(TestCaseDatabase):
         # Dave clicks the library to open it and sees that the content is
         # filled with the same information found on the normal search pages.
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -66,7 +66,8 @@ class TestReturnedSolrDataEpic(TestCaseDatabase):
         # The solr microservice goes down, I expect we should not rely on the
         # content to display something semi-nice in the mean time. So even
         # if it fails, we should get a 200 response
-        with MockSolrBigqueryService(status=500):
+        with MockSolrBigqueryService(status=500) as BQ, \
+                MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers

--- a/biblib/tests/functional_tests/test_teacher_epic.py
+++ b/biblib/tests/functional_tests/test_teacher_epic.py
@@ -19,7 +19,7 @@ from views import NO_PERMISSION_ERROR
 from flask import url_for
 from tests.stubdata.stub_data import UserShop, LibraryShop
 from tests.base import MockEmailService, MockSolrBigqueryService, \
-    TestCaseDatabase
+    TestCaseDatabase, MockEndPoint
 
 
 class TestDeletionEpic(TestCaseDatabase):
@@ -58,7 +58,10 @@ class TestDeletionEpic(TestCaseDatabase):
         for user in [user_student_1, user_student_2]:
             # The students check they can see the content
             url = url_for('libraryview', library=library_id_teacher)
-            with MockSolrBigqueryService():
+            with MockSolrBigqueryService() as BQ, \
+                    MockEndPoint([
+                        user_teacher, user_student_1, user_student_2
+                    ]) as EP:
                 response = self.client.get(
                     url,
                     headers=user.headers
@@ -86,7 +89,10 @@ class TestDeletionEpic(TestCaseDatabase):
 
             # The students check they can see the content
             url = url_for('libraryview', library=library_id_teacher)
-            with MockSolrBigqueryService():
+            with MockSolrBigqueryService() as BQ, \
+                    MockEndPoint([
+                        user_teacher, user_student_1, user_student_2
+                    ]) as EP:
                 response = self.client.get(
                     url,
                     headers=user.headers
@@ -100,14 +106,18 @@ class TestDeletionEpic(TestCaseDatabase):
         with MockEmailService(user_student_2):
             response = self.client.post(
                 url,
-                data=user_student_2.permission_view_post_data_json('read', False),
+                data=user_student_2.permission_view_post_data_json('read',
+                                                                   False),
                 headers=user_teacher.headers
             )
         self.assertEqual(response.status_code, 200)
 
         # Student 2 cannot see the content
         url = url_for('libraryview', library=library_id_teacher)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([
+                    user_teacher, user_student_1, user_student_2
+                ]) as EP:
             response = self.client.get(
                 url,
                 headers=user_student_2.headers
@@ -117,7 +127,10 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Student 1 can see the content still
         url = url_for('libraryview', library=library_id_teacher)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([
+                    user_teacher, user_student_1, user_student_2
+                ]) as EP:
             response = self.client.get(
                 url,
                 headers=user_student_1.headers

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -330,3 +330,16 @@ class LibraryShop(object):
                           'date_created', 'date_last_modified', 'permission',
                           'public', 'num_users', 'owner']
         return expected_types
+
+    @staticmethod
+    def library_view_get_response():
+        """
+        Expected return data from the user view GET end point
+
+        :return: GET data in dictionary format
+        """
+
+        expected_types = ['name', 'description', 'id', 'num_documents',
+                          'date_created', 'date_last_modified', 'permission',
+                          'public', 'num_users', 'owner']
+        return expected_types

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -192,7 +192,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library exists in the database
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -228,7 +229,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library exists in the database
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -553,7 +555,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library was created and documents exist
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -660,7 +663,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library is empty
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -752,7 +756,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check there is no document content
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -807,7 +812,8 @@ class TestWebservices(TestCaseDatabase):
         # does not have the permissions
         # Check the library is empty
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user_1, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user_2.headers
@@ -866,7 +872,8 @@ class TestWebservices(TestCaseDatabase):
 
         # The user can now access the content of the library
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockSolrBigqueryService() as BQ, \
+                MockEndPoint([stub_user_1, stub_user_2]) as ES:
             response = self.client.get(
                 url,
                 headers=stub_user_2.headers
@@ -1142,7 +1149,8 @@ class TestWebservices(TestCaseDatabase):
         # Request from user 2
         # Given it is public, should be able to view it
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService():
+        with MockEndPoint([stub_user_1, stub_user_2]) as ES,\
+                MockSolrBigqueryService() as BQ:
             response = self.client.get(
                 url,
                 headers=stub_user_2.headers

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -503,6 +503,7 @@ class UserView(BaseView):
                 num_users=num_users,
                 owner=owner
             )
+
             output_libraries.append(payload)
 
         return output_libraries
@@ -673,8 +674,8 @@ class LibraryView(BaseView):
     scopes = []
     rate_limit = [1000, 60*60*24]
 
-    @staticmethod
-    def get_documents_from_library(library_id):
+    @classmethod
+    def get_documents_from_library(cls, library_id, service_uid):
         """
         Retrieve all the documents that are within the library specified
         :param library_id: the unique ID of the library
@@ -682,8 +683,84 @@ class LibraryView(BaseView):
         :return: bibcodes
         """
 
+        # Get the library
         library = Library.query.filter(Library.id == library_id).one()
-        return library
+
+        # Get the owner of the library
+        result = db.session.query(Permissions, User)\
+            .join(Permissions.user)\
+            .filter(Permissions.library_id == library_id)\
+            .filter(Permissions.owner == True)\
+            .one()
+        owner_permissions, owner = result
+
+        service = '{api}/{uid}'.format(
+            api=current_app.config['BIBLIB_USER_EMAIL_ADSWS_API_URL'],
+            uid=owner.absolute_uid
+        )
+        current_app.logger.info('Obtaining email of user: {0} [API UID]'
+                                .format(owner.absolute_uid))
+        response = client().get(
+            service
+        )
+
+        # For this library get all the people who have permissions
+        users = Permissions.query.filter(
+            Permissions.library_id == library.id
+        ).all()
+
+        if response.status_code != 200:
+            current_app.logger.error('Could not find user in the API'
+                                     'database: {0}.'.format(service))
+            owner = 'Not available'
+        else:
+            owner = response.json()['email'].split('@')[0]
+
+        # User requesting to see the content
+        if service_uid:
+            try:
+                permission = Permissions.query.filter(
+                    Permissions.user_id == service_uid
+                ).filter(
+                    Permissions.library_id == library_id
+                ).one()
+
+                if permission.owner:
+                    main_permission = 'owner'
+                elif permission.admin:
+                    main_permission = 'admin'
+                elif permission.write:
+                    main_permission = 'write'
+                elif permission.read:
+                    main_permission = 'read'
+                else:
+                    main_permission = 'none'
+            except:
+                main_permission = 'none'
+        else:
+            main_permission = 'none'
+
+        if main_permission == 'owner' or main_permission == 'admin':
+            num_users = len(users)
+        elif library.public:
+            num_users = len(users)
+        else:
+            num_users = 0
+
+        metadata = dict(
+            name=library.name,
+            id='{0}'.format(cls.helper_uuid_to_slug(library.id)),
+            description=library.description,
+            num_documents=len(library.bibcode),
+            date_created=library.date_created.isoformat(),
+            date_last_modified=library.date_last_modified.isoformat(),
+            permission=main_permission,
+            public=library.public,
+            num_users=num_users,
+            owner=owner
+        )
+
+        return library, metadata
 
     @classmethod
     def read_access(cls, service_uid, library_id):
@@ -786,10 +863,20 @@ class LibraryView(BaseView):
         current_app.logger.info('User: {0} requested library: {1}'
                                 .format(user, library))
 
+        user_exists = self.helper_user_exists(absolute_uid=user)
+        if user_exists:
+            service_uid = \
+                self.helper_absolute_uid_to_service_uid(absolute_uid=user)
+        else:
+            service_uid = None
+
         # If the library is public, allow access
         try:
             # Try to load the dictionary and obtain the solr content
-            library = self.get_documents_from_library(library_id=library)
+            library, metadata = self.get_documents_from_library(
+                library_id=library,
+                service_uid=service_uid
+            )
             # pay attention to any functions that try to mutate the list
             # this will alter expected returns later
             documents = library.bibcode
@@ -804,7 +891,8 @@ class LibraryView(BaseView):
             # Make the response dictionary
             response = dict(
                 documents=documents,
-                solr=solr
+                solr=solr,
+                metadata=metadata
             )
 
         except Exception as error:

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -837,10 +837,21 @@ class LibraryView(BaseView):
         -----------
         documents:    <list>   Currently, a list containing the bibcodes.
         solr:         <dict>   The response from the solr bigquery end point
+        metadata:     <dict>   contains the following:
 
-        Note. in the future this will be modified to include all the content
-        of the library.
-
+          name:                 <string>  Name of the library
+          id:                   <string>  ID of the library
+          description:          <string>  Description of the library
+          num_documents:        <int>     Number of documents in the library
+          date_created:         <string>  ISO date library was created
+          date_last_modified:   <string>  ISO date library was last modified
+          permission:           <sting>   Permission type, can be: 'read',
+                                          'write', 'admin', or 'owner'
+          public:               <boolean> True means it is public
+          num_users:            <int>     Number of users with permissions to
+                                          this library
+          owner:                <string>  Identifier of the user who created
+                                          the library
         Permissions:
         -----------
         The following type of user can read a library:


### PR DESCRIPTION
The libraryview, ie., /libraries/<lib_id> now returns all the meta data
that you also get from the userview for an individual library.

Tests included to ensure expected behaviour.

Functional tests modified to ensure they work.