### PR TITLE
Feature/issue#56/update bibcodes from solr

### DIFF
--- a/biblib/models.py
+++ b/biblib/models.py
@@ -6,6 +6,7 @@ to be passed to the app creator within the Flask blueprint.
 """
 
 import uuid
+from utils import uniquify
 from datetime import datetime
 from flask.ext.sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
@@ -160,7 +161,7 @@ class MutableList(Mutable, list):
         :param value:
         :return:
         """
-        value = list(set(value))
+        value = uniquify(value)
         value = [item for item in value if item not in list(self)]
 
         self.extend(value)

--- a/biblib/tests/base.py
+++ b/biblib/tests/base.py
@@ -104,11 +104,11 @@ class MockSolrBigqueryService(MockADSWSAPI):
             :return:
             """
 
-            if self.kwargs.get('canonical_bibcode'):
-                docs = []
-                for i in range(len(self.kwargs.get('canonical_bibcode'))):
-                    bibcode = self.kwargs.get('canonical_bibcode')[i]
-                    docs.append({'bibcode': bibcode})
+            if self.kwargs.get('solr_docs'):
+                docs = self.kwargs['solr_docs']
+                # for i in range(len(self.kwargs.get('canonical_bibcode'))):
+                #     bibcode = self.kwargs.get('canonical_bibcode')[i]
+                #     docs.append({'bibcode': bibcode})
             else:
                 docs = [{'bibcode': 'bibcode'} for i
                         in range(self.kwargs.get('number_of_bibcodes', 1))]
@@ -128,6 +128,9 @@ class MockSolrBigqueryService(MockADSWSAPI):
                     'docs': docs
                 }
             }
+
+            if self.kwargs.get('fail', False):
+                resp.pop('response')
 
             resp = json.dumps(resp)
 

--- a/biblib/tests/base.py
+++ b/biblib/tests/base.py
@@ -104,6 +104,13 @@ class MockSolrBigqueryService(MockADSWSAPI):
             :return:
             """
 
+            if self.kwargs.get('canonical_bibcode'):
+                docs = []
+                for i in range(len(self.kwargs.get('canonical_bibcode'))):
+                    bibcode = self.kwargs.get('canonical_bibcode')[i]
+                    docs.append({'bibcode': bibcode})
+            else:
+                docs = [{'bibcode': 'bibcode'}]
             resp = {
                 'responseHeader': {
                     'status': 0,
@@ -117,11 +124,7 @@ class MockSolrBigqueryService(MockADSWSAPI):
                 'response': {
                     'numFound': 1,
                     'start': 0,
-                    'docs': [
-                        {
-                            'bibcode': 'bibcode'
-                        }
-                    ]
+                    'docs': docs
                 }
             }
 

--- a/biblib/tests/base.py
+++ b/biblib/tests/base.py
@@ -110,7 +110,8 @@ class MockSolrBigqueryService(MockADSWSAPI):
                     bibcode = self.kwargs.get('canonical_bibcode')[i]
                     docs.append({'bibcode': bibcode})
             else:
-                docs = [{'bibcode': 'bibcode'}]
+                docs = [{'bibcode': 'bibcode'} for i
+                        in range(self.kwargs.get('number_of_bibcodes', 1))]
             resp = {
                 'responseHeader': {
                     'status': 0,

--- a/biblib/tests/functional_tests/test_anonymous_epic.py
+++ b/biblib/tests/functional_tests/test_anonymous_epic.py
@@ -63,7 +63,8 @@ class TestAnonymousEpic(TestCaseDatabase):
 
         # Anonymous user tries to access the private library. But cannot.
         url = url_for('libraryview', library=library_id_private)
-        with MockSolrBigqueryService() as BQ, \
+
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEndPoint([user_dave, user_anonymous]) as EP:
             response = self.client.get(
                 url,
@@ -74,7 +75,7 @@ class TestAnonymousEpic(TestCaseDatabase):
 
         # Anonymous user tries to access the public library. And can.
         url = url_for('libraryview', library=library_id_public)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEndPoint([user_dave, user_anonymous]) as EP:
             response = self.client.get(
                 url,

--- a/biblib/tests/functional_tests/test_big_share_admin_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_admin_epic.py
@@ -74,8 +74,11 @@ class TestDeletionEpic(TestCaseDatabase):
                              len(stub_library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
+        canonical_bibcode = [i.bibcode[0] for i in libraries_added]
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_bibcode) as BQ, \
+                MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -142,8 +145,11 @@ class TestDeletionEpic(TestCaseDatabase):
             libraries_added.remove(libraries_added[i])
 
         # She checks that they got removed
+        canonical_bibcode = [i.bibcode[0] for i in libraries_added]
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_bibcode) as BQ, \
                 MockEndPoint([user_student, user_dave]) as EP:
             response = self.client.get(
                 url,
@@ -169,8 +175,10 @@ class TestDeletionEpic(TestCaseDatabase):
             libraries_added.append(library)
 
         # She checks that they got added
+        canonical_bibcode = [i.bibcode[0] for i in libraries_added]
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_bibcode) as BQ, \
                 MockEndPoint([user_dave, user_student]) as EP:
             response = self.client.get(
                 url,

--- a/biblib/tests/functional_tests/test_big_share_editor_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_editor_epic.py
@@ -65,14 +65,18 @@ class TestDeletionEpic(TestCaseDatabase):
                 headers=user_dave.headers
             )
             self.assertEqual(response.json['number_added'],
-                 len(library.bibcode))
+                             len(library.bibcode))
             self.assertEqual(response.status_code, 200, response)
 
             libraries_added.append(library)
 
         # Checks they are all in the library
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
+
+        canonical_bibcode = [i.bibcode[0] for i in libraries_added]
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_bibcode) as BQ, \
+                MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -104,8 +108,10 @@ class TestDeletionEpic(TestCaseDatabase):
         self.assertEqual(response.status_code, 200)
 
         # Mary looks at the library
+        canonical_bibcode = [i.bibcode[0] for i in libraries_added]
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_bibcode) as BQ, \
                 MockEndPoint([user_dave, user_dave]) as EP:
             response = self.client.get(
                 url,
@@ -134,8 +140,11 @@ class TestDeletionEpic(TestCaseDatabase):
             libraries_added.remove(libraries_added[i])
 
         # She checks that they got removed
+        canonical_bibcode = [i.bibcode[0] for i in libraries_added]
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_bibcode) as BQ, \
                 MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
@@ -160,10 +169,11 @@ class TestDeletionEpic(TestCaseDatabase):
             self.assertEqual(response.status_code, 200, response)
 
             libraries_added.append(library)
+            canonical_bibcode.extend(library.bibcode)
 
         # She checks that they got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(canonical_bibcode=canonical_bibcode) as BQ, \
                 MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,

--- a/biblib/tests/functional_tests/test_big_share_epic.py
+++ b/biblib/tests/functional_tests/test_big_share_epic.py
@@ -26,7 +26,7 @@ class TestDeletionEpic(TestCaseDatabase):
     Base class used to test the Big Share Epic
     """
 
-    def test_job_big_share(self):
+    def test_big_share(self):
         """
         Carries out the epic 'Big Share', where a user wants to share one of
         their big libraries they have created
@@ -86,7 +86,9 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Check they all got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
+        with MockSolrBigqueryService(
+                number_of_bibcodes=number_of_documents) as BQ, \
+                MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers
@@ -97,7 +99,8 @@ class TestDeletionEpic(TestCaseDatabase):
         # she cannot access the library.
         # Dave selects her e-mail address
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                number_of_bibcodes=number_of_documents) as BQ, \
                 MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
@@ -147,7 +150,8 @@ class TestDeletionEpic(TestCaseDatabase):
         # say she can see his libraries and is happy but wants to add content
         # herself
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                number_of_bibcodes=number_of_documents) as BQ, \
                 MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,
@@ -181,7 +185,8 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Mary realises she can no longer read content
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                number_of_bibcodes=number_of_documents) as BQ, \
                 MockEndPoint([user_dave, user_mary]) as EP:
             response = self.client.get(
                 url,

--- a/biblib/tests/functional_tests/test_job_epic.py
+++ b/biblib/tests/functional_tests/test_job_epic.py
@@ -96,7 +96,6 @@ class TestJobEpic(TestCaseDatabase):
                 url,
                 headers=user_mary.headers
             )
-        print response.json
         self.assertTrue(len(response.json['documents']) == 0, response.json)
 
         # Happy with her library, she copies the link to the library and

--- a/biblib/tests/functional_tests/test_job_epic.py
+++ b/biblib/tests/functional_tests/test_job_epic.py
@@ -90,18 +90,20 @@ class TestJobEpic(TestCaseDatabase):
 
         # Checks that there are no documents in the library
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, MockEndPoint([user_mary]) as EP:
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
+                MockEndPoint([user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_mary.headers
             )
+        print response.json
         self.assertTrue(len(response.json['documents']) == 0, response.json)
 
         # Happy with her library, she copies the link to the library and
         # e-mails it to the prospective employer.
 
         # She then asks a friend to check the link, and it works fine.
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEndPoint([user_mary, user_random]) as EP:
             response = self.client.get(
                 url,

--- a/biblib/tests/functional_tests/test_job_fast_epic.py
+++ b/biblib/tests/functional_tests/test_job_fast_epic.py
@@ -23,9 +23,9 @@ class TestJobEpic(TestCaseDatabase):
     Base class used to test the Job Epic
     """
 
-    def test_job_epic(self):
+    def test_fast_job_epic(self):
         """
-        Carries out the epic 'Job', where a user wants to add their articles to
+        Carries out the epic 'Fast Job', where a user wants to add their articles to
         their private libraries so that they can send it on to a prospective
         employer
 
@@ -59,7 +59,10 @@ class TestJobEpic(TestCaseDatabase):
 
         # She then asks a friend to check the link, and it works fine.
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, MockEndPoint([user_mary]) as EP:
+
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library.bibcode) as BQ, \
+                MockEndPoint([user_mary]) as EP:
             response = self.client.get(
                 url,
                 headers=user_random.headers

--- a/biblib/tests/functional_tests/test_retiring_librarian.py
+++ b/biblib/tests/functional_tests/test_retiring_librarian.py
@@ -70,7 +70,9 @@ class TestRetiringLibrarianEpic(TestCaseDatabase):
 
         # Check they all got added
         url = url_for('libraryview', library=library_id_dave)
-        with MockSolrBigqueryService() as BQ, MockEndPoint([user_dave]) as EP:
+        with MockSolrBigqueryService(
+                number_of_bibcodes=number_of_documents) as BQ, \
+                MockEndPoint([user_dave]) as EP:
             response = self.client.get(
                 url,
                 headers=user_dave.headers

--- a/biblib/tests/functional_tests/test_teacher_epic.py
+++ b/biblib/tests/functional_tests/test_teacher_epic.py
@@ -58,7 +58,7 @@ class TestDeletionEpic(TestCaseDatabase):
         for user in [user_student_1, user_student_2]:
             # The students check they can see the content
             url = url_for('libraryview', library=library_id_teacher)
-            with MockSolrBigqueryService() as BQ, \
+            with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                     MockEndPoint([
                         user_teacher, user_student_1, user_student_2
                     ]) as EP:
@@ -89,7 +89,7 @@ class TestDeletionEpic(TestCaseDatabase):
 
             # The students check they can see the content
             url = url_for('libraryview', library=library_id_teacher)
-            with MockSolrBigqueryService() as BQ, \
+            with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                     MockEndPoint([
                         user_teacher, user_student_1, user_student_2
                     ]) as EP:
@@ -114,7 +114,7 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Student 2 cannot see the content
         url = url_for('libraryview', library=library_id_teacher)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEndPoint([
                     user_teacher, user_student_1, user_student_2
                 ]) as EP:
@@ -127,7 +127,7 @@ class TestDeletionEpic(TestCaseDatabase):
 
         # Student 1 can see the content still
         url = url_for('libraryview', library=library_id_teacher)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEndPoint([
                     user_teacher, user_student_1, user_student_2
                 ]) as EP:

--- a/biblib/tests/unit_tests/test_utils.py
+++ b/biblib/tests/unit_tests/test_utils.py
@@ -1,0 +1,52 @@
+"""
+Tests the functions within the utils module
+"""
+
+import sys
+import os
+
+PROJECT_HOME = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../'))
+sys.path.append(PROJECT_HOME)
+
+
+import unittest
+from utils import uniquify
+
+class TestUtils(unittest.TestCase):
+    """
+    Class for testing the behaviour of the custom functions in the utils module
+    """
+
+    def test_uniquify_removes_duplication(self):
+        """
+        Tests the uniquify function that uniques the items in a list
+
+        :return: no return
+        """
+
+        non_unique_list = [1, 1, 2, 2, 3, 3, 4, 4]
+        unique_list = [1, 2, 3, 4]
+        uniqued_list = uniquify(non_unique_list)
+
+        # Ensure one value
+        for item in unique_list:
+            values = [i for i in uniqued_list if i == item]
+            self.assertEqual(1, len(values))
+
+    def test_uniquify_preserves(self):
+        """
+        Tests the uniquify function that uniques the items in a list
+
+        :return: no return
+        """
+
+        non_unique_list = [2, 2, 1, 1, 3, 3, 4, 4]
+        unique_list = [2, 1, 3, 4]
+        uniqued_list = uniquify(non_unique_list)
+
+        for i in range(len(unique_list)):
+            self.assertEqual(unique_list[i], uniqued_list[i])
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -883,18 +883,6 @@ class TestLibraryViews(TestCaseDatabase):
         self.assertNotEqual(library.bibcode, original_bibcodes)
         self.assertEqual(library.bibcode, canonical_bibcodes)
 
-    @unittest.skip('Not implemented')
-    def test_no_updates_if_solr_response_strange(self):
-        """
-        Tests that the solr data is used to update the database if the response
-        is normal.
-
-        :return: no return
-        """
-
-
-        self.fail()
-
     def test_user_without_permission_cannot_access_private_library(self):
         """
         Tests that the user requesting to see the contents of a library has

--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -891,6 +891,8 @@ class TestLibraryViews(TestCaseDatabase):
 
         :return: no return
         """
+
+
         self.fail()
 
     def test_user_without_permission_cannot_access_private_library(self):

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -274,7 +274,9 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library exists in the database
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService(canonical_bibcode=canonical_biblist):
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_biblist) as BQ, \
+                MockEndPoint([stub_user]) as EP:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -326,7 +328,9 @@ class TestWebservices(TestCaseDatabase):
         # Check the library exists in the database
         canonical_biblist.pop()
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService(canonical_bibcode=canonical_biblist):
+        with MockSolrBigqueryService(
+                canonical_bibcode=canonical_biblist) as BQ, \
+                MockEndPoint([stub_user]) as EP:
             response = self.client.get(
                 url,
                 headers=stub_user.headers
@@ -977,7 +981,7 @@ class TestWebservices(TestCaseDatabase):
 
         # The user can now access the content of the library
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService(number_of_bibcodes) as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEndPoint([stub_user_1, stub_user_2]) as ES:
             response = self.client.get(
                 url,

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -192,7 +192,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library exists in the database
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library.bibcode) as BQ, \
                 MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
@@ -256,8 +257,8 @@ class TestWebservices(TestCaseDatabase):
         canonical_biblist = fake_biblist(10)
         non_canonical_biblist = canonical_biblist[:]
 
-        non_canonical_biblist[1] = 'arXiV' + non_canonical_biblist[1]
-        non_canonical_biblist[5] = 'arXiV' + non_canonical_biblist[5]
+        non_canonical_biblist[1] = 'arXiv' + non_canonical_biblist[1]
+        non_canonical_biblist[5] = 'arXiv' + non_canonical_biblist[5]
 
         post_data['bibcode'] = non_canonical_biblist
 
@@ -606,7 +607,8 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library was created and documents exist
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library.bibcode) as BQ, \
                 MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
@@ -714,7 +716,7 @@ class TestWebservices(TestCaseDatabase):
 
         # Check the library is empty
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEmailService(stub_user, end_type='uid') as ES:
             response = self.client.get(
                 url,
@@ -862,13 +864,15 @@ class TestWebservices(TestCaseDatabase):
         # Request from user 2 to see the library should be refused if user 2
         # does not have the permissions
         # Check the library is empty
+        print stub_library.user_view_post_data_json
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEmailService(stub_user_1, end_type='uid') as ES:
             response = self.client.get(
                 url,
                 headers=stub_user_2.headers
             )
+        print response.json
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
 
@@ -923,7 +927,7 @@ class TestWebservices(TestCaseDatabase):
 
         # The user can now access the content of the library
         url = url_for('libraryview', library=library_id)
-        with MockSolrBigqueryService() as BQ, \
+        with MockSolrBigqueryService(number_of_bibcodes) as BQ, \
                 MockEndPoint([stub_user_1, stub_user_2]) as ES:
             response = self.client.get(
                 url,
@@ -1201,7 +1205,7 @@ class TestWebservices(TestCaseDatabase):
         # Given it is public, should be able to view it
         url = url_for('libraryview', library=library_id)
         with MockEndPoint([stub_user_1, stub_user_2]) as ES,\
-                MockSolrBigqueryService() as BQ:
+                MockSolrBigqueryService(number_of_bibcodes=0) as BQ:
             response = self.client.get(
                 url,
                 headers=stub_user_2.headers

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -15,7 +15,7 @@ from flask import url_for
 from views import DUPLICATE_LIBRARY_NAME_ERROR, MISSING_LIBRARY_ERROR, \
     MISSING_USERNAME_ERROR, NO_PERMISSION_ERROR, DEFAULT_LIBRARY_NAME_PREFIX, \
     DEFAULT_LIBRARY_DESCRIPTION, WRONG_TYPE_ERROR, \
-    API_MISSING_USER_EMAIL
+    API_MISSING_USER_EMAIL, SOLR_RESPONSE_MISMATCH_ERROR
 from tests.stubdata.stub_data import LibraryShop, UserShop, fake_biblist
 from tests.base import MockEmailService, MockSolrBigqueryService,\
     TestCaseDatabase, MockEndPoint
@@ -290,6 +290,58 @@ class TestWebservices(TestCaseDatabase):
         for doc in solr_docs:
             self.assertIn(doc['bibcode'], lib_docs)
             self.assertIn(doc['bibcode'], canonical_biblist)
+
+    def test_solr_does_not_update_if_weird_response(self):
+        """
+        Test the /libraries/<> such that the library bibcodes are not updated if
+        the solr data returns a differently sized bibcode
+
+        :return: no return
+        """
+
+        # Stub data
+        stub_user = UserShop()
+        stub_library = LibraryShop(want_bibcode=True)
+
+        # Make the library
+        post_data = stub_library.user_view_post_data
+        canonical_biblist = fake_biblist(10)
+        non_canonical_biblist = canonical_biblist[:]
+
+        non_canonical_biblist[1] = 'arXiv' + non_canonical_biblist[1]
+        non_canonical_biblist[5] = 'arXiv' + non_canonical_biblist[5]
+
+        post_data['bibcode'] = non_canonical_biblist
+
+        # Make the library
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=json.dumps(post_data),
+            headers=stub_user.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        library_id = response.json['id']
+
+        # Check the library exists in the database
+        canonical_biblist.pop()
+        url = url_for('libraryview', library=library_id)
+        with MockSolrBigqueryService(canonical_bibcode=canonical_biblist):
+            response = self.client.get(
+                url,
+                headers=stub_user.headers
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('documents', response.json)
+        self.assertIn('solr', response.json)
+        self.assertEqual(SOLR_RESPONSE_MISMATCH_ERROR['body'],
+                         response.json['solr'])
+
+        # Check that the solr docs did not change the docs
+        lib_docs = response.json['documents']
+
+        self.assertEqual(lib_docs, non_canonical_biblist)
+        self.assertNotEqual(lib_docs, canonical_biblist)
 
     def test_create_library_resource_and_add_bibcodes_of_wrong_type(self):
         """

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -864,7 +864,6 @@ class TestWebservices(TestCaseDatabase):
         # Request from user 2 to see the library should be refused if user 2
         # does not have the permissions
         # Check the library is empty
-        print stub_library.user_view_post_data_json
         url = url_for('libraryview', library=library_id)
         with MockSolrBigqueryService(number_of_bibcodes=0) as BQ, \
                 MockEmailService(stub_user_1, end_type='uid') as ES:
@@ -872,7 +871,6 @@ class TestWebservices(TestCaseDatabase):
                 url,
                 headers=stub_user_2.headers
             )
-        print response.json
         self.assertEqual(response.status_code, NO_PERMISSION_ERROR['number'])
         self.assertEqual(response.json['error'], NO_PERMISSION_ERROR['body'])
 

--- a/biblib/utils.py
+++ b/biblib/utils.py
@@ -41,6 +41,11 @@ def err(error_dictionary):
     """
     return {'error': error_dictionary['body']}, error_dictionary['number']
 
+def uniquify(seq):
+    seen = set()
+    seen_add = seen.add
+    return [ x for x in seq if not (x in seen or seen_add(x))]
+
 class BackendIntegrityError(Exception):
     """
     Custom exception that is raised when there are application errors similar

--- a/biblib/utils.py
+++ b/biblib/utils.py
@@ -41,10 +41,22 @@ def err(error_dictionary):
     """
     return {'error': error_dictionary['body']}, error_dictionary['number']
 
-def uniquify(seq):
+def uniquify(input_list):
+    """
+    Finds the unique values in a list. This keeps the order of the list, as
+    opposed to the standard list(set()) method.
+
+    Adopted from: http://stackoverflow.com/
+    questions/
+    480214/
+    how-do-you-remove-duplicates-from-a-list-in-python-whilst-preserving-order
+    :param input_list: list that can contain duplicates
+
+    :return: same ordered list without duplications
+    """
     seen = set()
     seen_add = seen.add
-    return [ x for x in seq if not (x in seen or seen_add(x))]
+    return [item for item in input_list if not (item in seen or seen_add(item))]
 
 class BackendIntegrityError(Exception):
     """

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -938,18 +938,19 @@ class LibraryView(BaseView):
 
             # Now check if we can update the library database based on the
             # returned canonical bibcodes
-            if not solr.get('response') \
-                    or len(solr['response']['docs']) != len(library.bibcode):
+            if solr.get('response') \
+                    and len(solr['response']['docs']) == len(library.bibcode):
+                # Update bibcodes based on solr
+                solr_bibcodes = \
+                    [i['bibcode'] for i in solr['response']['docs']]
+
+                self.solr_update_library(library=library,
+                                         solr_bibcodes=solr_bibcodes)
+            else:
+                solr = SOLR_RESPONSE_MISMATCH_ERROR['body']
                 current_app.logger.warning('Problem with solr response: {0}'
                                            .format(solr))
-                return err(SOLR_RESPONSE_MISMATCH_ERROR)
 
-            # Update bibcodes based on solr
-            solr_bibcodes = \
-                [i['bibcode'] for i in solr['response']['docs']]
-
-            self.solr_update_library(library=library,
-                                     solr_bibcodes=solr_bibcodes)
             # Make the response dictionary
             response = dict(
                 documents=library.bibcode,

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -56,6 +56,11 @@ API_MISSING_USER_UID = dict(
     body='User does not exist in the API database',
     number=404
 )
+SOLR_RESPONSE_MISMATCH_ERROR = dict(
+    body='Solr response does not contain the same number of bibcodes as the '
+         'request.',
+    number=404
+)
 
 
 class BaseView(Resource):
@@ -791,13 +796,14 @@ class LibraryView(BaseView):
         :return: solr bigquery end point response
         """
 
-        bibcodes = 'bibcode\n' + '\n'.join(bibcodes)
+        bibcodes_string = 'bibcode\n' + '\n'.join(bibcodes)
 
         params = {
             'q': '*:*',
             'wt': 'json',
-            'fl': 'title,abstract,bibcode,author,aff,links_data,property,[citations],pub,pubdate',
-            'rows': "1000", 
+            'fl': 'title,abstract,bibcode,author,aff,links_data,'
+                  'property,[citations],pub,pubdate',
+            'rows': '1000',
             'fq': '{!bitset}'
         }
 
@@ -805,15 +811,47 @@ class LibraryView(BaseView):
             'Content-Type': 'big-query/csv',
         }
         current_app.logger.info('Querying Solr bigquery microservice: {0}, {1}'
-                                .format(params, bibcodes.replace('\n', ',')))
+                                .format(params,
+                                        bibcodes_string.replace('\n', ',')))
         response = client().post(
             url=current_app.config['BIBLIB_SOLR_BIG_QUERY_URL'],
             params=params,
-            data=bibcodes,
+            data=bibcodes_string,
             headers=headers
         )
 
         return response
+
+    @staticmethod
+    def solr_update_library(library, solr_bibcodes):
+        """
+        Updates the library based on the solr canonical bibcodes response
+        :param library: library to update
+        :param solr_bibcodes: solr bigquery response
+
+        :return: no return
+        """
+
+        update = False
+        new_bibcode = []
+
+        for i in range(len(library.bibcode)):
+            if library.bibcode[i] != solr_bibcodes[i]:
+                current_app.logger.info('Updating bibcode: {0} to {1}'
+                                        .format(
+                                            library.bibcode[i],
+                                            solr_bibcodes[i]
+                                        )
+                )
+                new_bibcode.append(solr_bibcodes[i])
+                update = True
+            else:
+                new_bibcode.append(library.bibcode[i])
+
+        if update:
+            library.bibcode = new_bibcode
+            db.session.add(library)
+            db.session.commit()
 
     # Methods
     def get(self, library):
@@ -905,6 +943,17 @@ class LibraryView(BaseView):
                 solr=solr,
                 metadata=metadata
             )
+
+            # Now check if we can update the library database based on the
+            # returned canonical bibcodes
+            if not solr.get('response') \
+                    or len(solr['response']['docs']) != len(library.bibcode):
+                return err(SOLR_RESPONSE_MISMATCH_ERROR)
+
+            # Update bibcodes based on solr
+            solr_bibcodes = \
+                [i['bibcode'] for i in solr['response']['docs']]
+            self.solr_update_library(library=library, solr=solr)
 
         except Exception as error:
             current_app.logger.warning(

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -330,8 +330,6 @@ class UserView(BaseView):
     End point to create a library for a given user
     """
 
-    # TODO: must give the library name/missing input function saves time
-
     decorators = [advertise('scopes', 'rate_limit')]
     scopes = []
     rate_limit = [1000, 60*60*24]
@@ -669,12 +667,6 @@ class LibraryView(BaseView):
     The GET requests are separate from the POST, DELETE requests as this class
     must be scopeless, whereas the others will have scope.
     """
-
-    # TODO: need to ignore the anon user. Currently scopeless
-    # TODO: document already exists (only add a bibcode once)
-    # TODO: adding tags using PUT for RESTful endpoint?
-    # TODO: public/private behaviour
-
     decorators = [advertise('scopes', 'rate_limit')]
     scopes = []
     rate_limit = [1000, 60*60*24]
@@ -916,9 +908,6 @@ class LibraryView(BaseView):
           - write
           - read
         """
-
-        # TODO: Needs authentification still
-
         try:
             user = int(request.headers[USER_ID_KEYWORD])
         except KeyError:

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -12,7 +12,7 @@ from client import client
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from utils import get_post_data, BackendIntegrityError, \
-    PermissionDeniedError, err
+    PermissionDeniedError, err, uniquify
 
 # Constant definitions
 API_HELP = 'http://adsabs.github.io/help/api/'
@@ -387,7 +387,7 @@ class UserView(BaseView):
             if _bibcode and isinstance(_bibcode, list):
 
                 # Ensure unique content
-                _bibcode = list(set(_bibcode))
+                _bibcode = uniquify(_bibcode)
                 current_app.logger.info('User supplied bibcodes: {0}'
                                         .format(_bibcode))
                 library.bibcode = _bibcode
@@ -928,32 +928,34 @@ class LibraryView(BaseView):
             )
             # pay attention to any functions that try to mutate the list
             # this will alter expected returns later
-            documents = library.bibcode
 
             try:
-                solr = self.solr_big_query(bibcodes=documents).json()
+                solr = self.solr_big_query(bibcodes=library.bibcode).json()
             except Exception as error:
                 current_app.logger.warning('Could not parse solr data: {0}'
                                            .format(error))
                 solr = {'error': 'Could not parse solr data'}
 
-            # Make the response dictionary
-            response = dict(
-                documents=documents,
-                solr=solr,
-                metadata=metadata
-            )
-
             # Now check if we can update the library database based on the
             # returned canonical bibcodes
             if not solr.get('response') \
                     or len(solr['response']['docs']) != len(library.bibcode):
+                current_app.logger.warning('Problem with solr response: {0}'
+                                           .format(solr))
                 return err(SOLR_RESPONSE_MISMATCH_ERROR)
 
             # Update bibcodes based on solr
             solr_bibcodes = \
                 [i['bibcode'] for i in solr['response']['docs']]
-            self.solr_update_library(library=library, solr=solr)
+
+            self.solr_update_library(library=library,
+                                     solr_bibcodes=solr_bibcodes)
+            # Make the response dictionary
+            response = dict(
+                documents=library.bibcode,
+                solr=solr,
+                metadata=metadata
+            )
 
         except Exception as error:
             current_app.logger.warning(
@@ -1035,7 +1037,10 @@ class DocumentView(BaseView):
         db.session.add(library)
         db.session.commit()
 
-        current_app.logger.info(library.bibcode)
+        current_app.logger.info('Added: {0} is now {1}'.format(
+            document_data['bibcode'],
+            library.bibcode)
+        )
 
         end_length = len(library.bibcode)
 


### PR DESCRIPTION
* Added the functionality to update the documents based on the solr response.

  * If the bibcodes are the canonical form, then they are not updated.
    
  * If the bibcode is an alternate bibcode, then it is converted to its canonical bibcode using a hashmap. If the new bibcode is not in the new list, then add it, otherwise discard the bibcode.
    
* Included a uniquify function as using set(list()) changes the order of the original list, which can cause some problems for testing. Should also be faster anyway.
    
* Tests for utils added specifically for uniquify.

* All tests modified for the updates made to the stub data and mocking services.