### PR TITLE
Issue #75 closes and addresses all requirements at this time

### DIFF
--- a/biblib/tests/unit_tests/test_views.py
+++ b/biblib/tests/unit_tests/test_views.py
@@ -880,8 +880,15 @@ class TestLibraryViews(TestCaseDatabase):
 
         # Now check solr updates the records correctly
         solr_docs = response_library['response']['docs']
-        self.library_view.solr_update_library(library=library,
-                                              solr_docs=solr_docs)
+        updates = self.library_view.solr_update_library(library=library,
+                                                        solr_docs=solr_docs)
+
+        # Check the data returned is correct on what files were updated and why
+        self.assertEqual(updates['num_updated'], 1)
+        self.assertEqual(updates['duplicates_removed'], 0)
+        update_list = updates['update_list']
+        self.assertEqual(update_list[0]['arXivtest3'],
+                         'test3')
 
         library = Library.query.filter(Library.id == library.id).one()
         self.assertNotEqual(library.bibcode, original_bibcodes)
@@ -936,8 +943,16 @@ class TestLibraryViews(TestCaseDatabase):
 
         # Now check solr updates the records correctly
         solr_docs = response_library['response']['docs']
-        self.library_view.solr_update_library(library=library,
-                                              solr_docs=solr_docs)
+        updates = self.library_view.solr_update_library(library=library,
+                                                        solr_docs=solr_docs)
+
+        self.assertEqual(updates['num_updated'], 2)
+        self.assertEqual(updates['duplicates_removed'], 1)
+        update_list = updates['update_list']
+        self.assertEqual(update_list[0]['arXivtest3'],
+                         'test3')
+        self.assertEqual(update_list[1]['conftest3'],
+                         'test3')
 
         library = Library.query.filter(Library.id == library.id).one()
         self.assertNotEqual(library.bibcode, original_bibcodes)

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -315,12 +315,26 @@ class TestWebservices(TestCaseDatabase):
         self.assertEqual(response.status_code, 200)
         self.assertIn('documents', response.json)
         self.assertIn('solr', response.json)
+        self.assertIn('metadata', response.json)
+        self.assertIn('updates', response.json)
 
         # Check that the solr docs updated the library docs
         lib_docs = response.json['documents']
 
         self.assertEqual(canonical_biblist, lib_docs)
         self.assertNotEqual(original_bibcodes, lib_docs)
+
+        # Check the data returned is correct on what files were updated and why
+        updates = response.json['updates']
+        self.assertEqual(updates['num_updated'], 3)
+        self.assertEqual(updates['duplicates_removed'], 1)
+        update_list = updates['update_list']
+        self.assertEqual(update_list[0]['arXiv1976.....LWW......L'],
+                         '1976.....LWW......L')
+        self.assertEqual(update_list[1]['arXiv2010.....KPK......K'],
+                         '2010.....KPK......K')
+        self.assertEqual(update_list[2]['arXiv2014.....KTC......K'],
+                         '2010.....KPK......K')
 
     def test_solr_does_not_update_if_weird_response(self):
         """


### PR DESCRIPTION
Return data from the documentsview end point has been updated such
that it contains relevant information that describes the modifications
that were made to the documents based on the return content from solr.

Currently, it returns:
  - number of updated documents
  - number of bibcodes removed due to duplication
  - a list containing the bibcodes and their updated version