### PR TITLE
Issue #76: closes and addresses cronjob required for production

### DIFF
--- a/biblib/tests/unit_tests/test_manage.py
+++ b/biblib/tests/unit_tests/test_manage.py
@@ -148,7 +148,7 @@ class TestManagePy(unittest.TestCase):
             library_2_id = library_2.id
 
             # Now run the stale deletion
-            DeleteStaleUsers.run()
+            DeleteStaleUsers().run(config_type='TEST')
 
             # Check the state of users, libraries and permissions
             # User 2

--- a/biblib/views.py
+++ b/biblib/views.py
@@ -922,7 +922,7 @@ class LibraryView(BaseView):
 
           num_updated:          <int>     Number of documents modified based on
                                           the response from solr
-          duplicates_removed:   <int>     Number of files removed for because
+          duplicates_removed:   <int>     Number of files removed because
                                           they are duplications
           update_list:          <list>[<dict>]
                                           List of dictionaries such that a

--- a/scripts/cronjob.sh
+++ b/scripts/cronjob.sh
@@ -1,0 +1,1 @@
+* 1 * * * /usr/bin/python /biblib/biblib/manage.py syncdb --config_type CONSUL >> /tmp/biblib_delete_stale_users.log


### PR DESCRIPTION
Added a cronjob that can be run once every day at 1 am to remove stale users.

To keep the configuration as-is, a command line argument was allowed to be
passed to the Flask-Script Command class. This means on deployment, and in
testing, both versions of the script should behave as expected.

No tests added, just updated.

Minor spelling modification in views.py.