### PR TITLE
AWS-211 implement get classic libraries

### DIFF
--- a/biblib/app.py
+++ b/biblib/app.py
@@ -4,7 +4,7 @@ Application
 
 import logging.config
 from views import UserView, LibraryView, DocumentView, PermissionView, \
-    TransferView
+    TransferView, ClassicView
 from models import db
 
 from flask import Flask
@@ -54,6 +54,11 @@ def create_app():
     api.add_resource(TransferView,
                      '/transfer/<string:library>',
                      methods=['POST'])
+
+    api.add_resource(ClassicView,
+                     '/classic',
+                     methods=['GET']
+                     )
 
     return app
 

--- a/biblib/config.py
+++ b/biblib/config.py
@@ -47,6 +47,7 @@ BIBLIB_LOGGING = {
 
 # These lines are necessary only if the app needs to be a client of the
 # adsws-api
+BIBLIB_CLASSIC_SERVICE_URL = 'https://api.adsabs.edu/v1/harbour'
 BIBLIB_SOLR_BIG_QUERY_URL = 'https://api.adsabs.search/v1/bigquery'
 BIBLIB_USER_EMAIL_ADSWS_API_URL = 'https://api.adsabs.harvard.edu/v1/user'
 BIBLIB_ADSWS_API_TOKEN = 'this is a secret api token!'

--- a/biblib/tests/functional_tests/test_bb_and_classic_user_epic.py
+++ b/biblib/tests/functional_tests/test_bb_and_classic_user_epic.py
@@ -1,0 +1,156 @@
+"""
+Functional test
+
+Bumblebee and Clasic User Epic
+
+Storyboard is defined within the comments of the program itself
+"""
+
+import unittest
+
+from httmock import HTTMock, urlmatch
+from flask import url_for
+from biblib.tests.stubdata.stub_data import UserShop, LibraryShop
+from biblib.tests.base import TestCaseDatabase, MockEmailService, \
+    MockSolrBigqueryService, MockEndPoint, MockClassicService
+from biblib.views.http_errors import NO_CLASSIC_ACCOUNT
+from biblib.config import BIBLIB_CLASSIC_SERVICE_URL
+
+
+class TestBBClassicUserEpic(TestCaseDatabase):
+    """
+    Base class used to test the Bumblebee and Classic User Epic
+    """
+
+    def test_bb_classic_user_epic(self):
+        """
+        Carries out the epic 'Bumblebee and Classic User', where a user that
+        comes to the new interface makes some libraries, and has some permission
+        to access other libraries from other users.
+        The user then imports some libraries from ADS Classic, where some have
+        similar names with that of the ones they previously made. It is assumed
+        they have already setup their ADS credentials
+        """
+        # Stub data
+        user_gpa = UserShop()
+        user_mary = UserShop()
+        stub_library_1 = LibraryShop(want_bibcode=True, public=True)
+        stub_library_2 = LibraryShop(want_bibcode=True, public=True)
+
+        # Gpa navigates the search pages and adds some bibcodes to some a few
+        # libraries.
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library_1.user_view_post_data_json,
+            headers=user_gpa.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['bibcode'], stub_library_1.get_bibcodes())
+
+        # A friend adds them to one of their libraries with a similar name
+        # # Make library
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library_1.user_view_post_data_json,
+            headers=user_mary.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['bibcode'], stub_library_1.get_bibcodes())
+        library_id_mary = response.json['id']
+
+        # # Permission to read
+        url = url_for('permissionview', library=library_id_mary)
+        with MockEmailService(user_gpa):
+            response = self.client.post(
+                url,
+                data=user_gpa.permission_view_post_data_json('read', True),
+                headers=user_mary.headers
+            )
+        self.assertEqual(response.status_code, 200)
+
+        # Gpa imports all libraries from ADS Classic
+        stub_library_2.bibcode = stub_library_1.bibcode.copy()
+        stub_library_2.bibcode['new bibcode'] = {}
+
+        url = url_for('classicview')
+        with MockClassicService(status=200, libraries=[stub_library_2]):
+            response = self.client.get(url, headers=user_gpa.headers)
+        self.assertEqual(response.status_code, 200)
+
+        # Gpa checks that the libraries were imported, and didn't affect the
+        # friends libraries
+        library_id_gpa = response.json[0]['library_id']
+
+        url = url_for('libraryview', library=library_id_gpa)
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library_2.get_bibcodes()) as BQ, \
+                MockEndPoint([user_gpa]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_gpa.headers
+            )
+        self.assertIn('new bibcode', response.json['documents'])
+
+        # Check Mary's library
+        url = url_for('userview')
+        with MockEmailService(user_mary, end_type='uid'):
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+        self.assertTrue(len(response.json['libraries']), 1)
+        self.assertEqual(response.json['libraries'][0]['name'], stub_library_1.name)
+
+        url = url_for('libraryview', library=library_id_mary)
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library_1.get_bibcodes()) as BQ, \
+                MockEndPoint([user_mary]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+        self.assertNotIn('new bibcode', response.json['documents'])
+
+        # Gpa then re-imports again by accident, but this is fine as this should
+        # be an indempotent process
+        url = url_for('classicview')
+        with MockClassicService(status=200, libraries=[stub_library_2]):
+            response = self.client.get(url, headers=user_gpa.headers)
+        self.assertEqual(response.status_code, 200)
+        library_id_gpa = response.json[0]['library_id']
+
+        url = url_for('libraryview', library=library_id_gpa)
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library_2.get_bibcodes()) as BQ, \
+                MockEndPoint([user_gpa]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_gpa.headers
+            )
+        self.assertIn('new bibcode', response.json['documents'])
+
+        # Check Mary's library
+        url = url_for('userview')
+        with MockEmailService(user_mary, end_type='uid'):
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+        self.assertTrue(len(response.json['libraries']), 1)
+        self.assertEqual(response.json['libraries'][0]['name'], stub_library_1.name)
+
+        url = url_for('libraryview', library=library_id_mary)
+        with MockSolrBigqueryService(
+                canonical_bibcode=stub_library_1.get_bibcodes()) as BQ, \
+                MockEndPoint([user_mary]) as EP:
+            response = self.client.get(
+                url,
+                headers=user_mary.headers
+            )
+        self.assertNotIn('new bibcode', response.json['documents'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/functional_tests/test_classic_user_epic.py
+++ b/biblib/tests/functional_tests/test_classic_user_epic.py
@@ -1,0 +1,86 @@
+"""
+Functional test
+
+Clasic User Epic
+
+Storyboard is defined within the comments of the program itself
+"""
+
+import unittest
+
+from httmock import HTTMock, urlmatch
+from flask import url_for
+from biblib.tests.stubdata.stub_data import UserShop, LibraryShop
+from biblib.tests.base import TestCaseDatabase, MockEmailService, \
+    MockSolrBigqueryService, MockEndPoint, MockClassicService
+from biblib.views.http_errors import NO_CLASSIC_ACCOUNT
+from biblib.config import BIBLIB_CLASSIC_SERVICE_URL
+
+
+@urlmatch(netloc=r'(.*\.)?{}.*'.format(BIBLIB_CLASSIC_SERVICE_URL))
+def classic_service_404(url, request):
+    return {
+        'status_code': NO_CLASSIC_ACCOUNT['number'],
+        'content': NO_CLASSIC_ACCOUNT['body']
+    }
+
+
+class TestClassicUserEpic(TestCaseDatabase):
+    """
+    Base class used to test the Classic User Epic
+    """
+
+    def test_classic_user_epic(self):
+        """
+        Carries out the epic 'Classic User', where a user that previously used
+        ADS Classic has come to the new interface and has decided to import
+        contents from ADS Classic. They have not yet made any libraries, and
+        have not set up their ADS Classic account in BB yet.
+        """
+        # Stub data
+        user_gpa = UserShop()
+        stub_library_1 = LibraryShop(public=True)
+        stub_library_2 = LibraryShop(public=True)
+
+        # Gpa navigates to the libraries page and tries to import their libraries
+        # from ADS Classic. However, Gpa has not setup any ADS Credentials
+        url = url_for('classicview')
+        with MockClassicService(status=NO_CLASSIC_ACCOUNT['number'], body={'error': NO_CLASSIC_ACCOUNT['body']}):
+            response = self.client.get(url, headers=user_gpa.headers)
+        self.assertEqual(response.status_code, NO_CLASSIC_ACCOUNT['number'])
+        self.assertEqual(response.json['error'], NO_CLASSIC_ACCOUNT['body'])
+
+        # They visit the relevant page and setup their ADS Classic credentials
+        # They then try again to import the libraries from ADS Classic
+        with MockClassicService(status=200, libraries=[stub_library_1, stub_library_2]):
+            response = self.client.get(url, headers=user_gpa.headers)
+
+        self.assertEqual(response.status_code, 200)
+
+        # Gpa visit the libraries pages to check that it was in fact imported
+        url = url_for('userview')
+        with MockEmailService(user_gpa, end_type='uid'):
+            response = self.client.get(
+                url,
+                headers=user_gpa.headers
+            )
+        self.assertEqual(response.json['libraries'][0]['name'], stub_library_1.name)
+        self.assertEqual(response.json['libraries'][1]['name'], stub_library_2.name)
+        library_id_1 = response.json['libraries'][0]['id']
+        library_id_2 = response.json['libraries'][1]['id']
+
+        # Gpa clicks the library page and checks that the content is as expected
+        for library_id, stub_library in [[library_id_1, stub_library_1], [library_id_2, stub_library_2]]:
+            url = url_for('libraryview', library=library_id)
+            with MockSolrBigqueryService(canonical_bibcodes=stub_library_1.get_bibcodes()) as BQ, \
+                    MockEndPoint([user_gpa]) as EP:
+                response = self.client.get(
+                    url,
+                    headers=user_gpa.headers
+                )
+            self.assertTrue(len(response.json['documents']) == len(stub_library.get_bibcodes()), response.json)
+            self.assertEqual(stub_library.get_bibcodes(), response.json['documents'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/biblib/tests/stubdata/stub_data.py
+++ b/biblib/tests/stubdata/stub_data.py
@@ -328,6 +328,17 @@ class LibraryShop(object):
                                                public=public)
         return json.dumps(put_data)
 
+    def classic_view_data(self):
+        """
+        JSON expected for classic view
+        :return:
+        """
+        return {
+            'name': self.name,
+            'description': self.description,
+            'documents': self.get_bibcodes()
+        }
+
     @staticmethod
     def user_view_get_response():
         """

--- a/biblib/views/__init__.py
+++ b/biblib/views/__init__.py
@@ -13,3 +13,4 @@ from library_view import LibraryView
 from document_view import DocumentView
 from permission_view import PermissionView
 from transfer_view import TransferView
+from classic_view import ClassicView

--- a/biblib/views/classic_view.py
+++ b/biblib/views/classic_view.py
@@ -1,0 +1,156 @@
+"""
+User view
+"""
+
+from ..utils import err
+from ..models import db, User, Library, Permissions
+from ..client import client
+from base_view import BaseView
+from flask import current_app
+from flask.ext.discoverer import advertise
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
+from http_errors import MISSING_USERNAME_ERROR
+
+
+class ClassicView(BaseView):
+    """
+    End point to import libraries from ADS Classic
+    """
+
+    decorators = [advertise('scopes', 'rate_limit')]
+    scopes = ['user']
+    rate_limit = [1000, 60*60*24]
+
+    @staticmethod
+    def upsert_library(service_uid, library):
+        """
+        Upsert a library into the database. This entails:
+          - Adding a library and bibcodes if there is no name conflict
+          - Not adding a library if name matches, but compare bibcodes
+
+        :param service_uid: microservice UID of the user
+        :param library: dictionary of the form:
+            {'name': str, 'description': str, 'documents': [str, ...., str]}
+
+        :return: boolean for success
+        """
+        # Make the permissions
+        user = User.query.filter(User.id == service_uid).one()
+
+        try:
+            # XXX: is a join faster or slower than this logic? or is it even
+            #      important in this scenario?
+
+            # Find all the permissions of the user
+            permissions = Permissions.query\
+                .filter(Permissions.user_id == user.id)\
+                .filter(Permissions.owner == True)\
+                .all()
+            if len(permissions) == 0:
+                raise NoResultFound
+
+            # Collect all the libraries for which they are the owner
+            libs = [Library.query.filter(Library.id == permission.library_id).one() for permission in permissions]
+            lib = [lib_ for lib_ in libs if lib_.name == library['name']]
+
+            # Raise if there is not exactly one, it should be 1 or 0, but if
+            # multiple are returned, there is some problem
+            if len(lib) == 0:
+                raise NoResultFound
+                current_app.logger.info(
+                    'User does not have a library with this name'
+                )
+            elif len(lib) > 1:
+                current_app.logger.warning(
+                    'More than 1 library has the same name,'
+                    ' this should not happen: {}'.format(lib)
+                )
+                raise IntegrityError
+
+            # Get the single record returned, as names are considered unique in
+            # the workflow of creating libraries
+            lib = lib[0]
+
+            bibcode_before = len(lib.get_bibcodes())
+            lib.add_bibcodes(library['documents'])
+            bibcode_added = len(lib.get_bibcodes()) - bibcode_before
+            action = 'updated'
+            db.session.add(lib)
+
+        except NoResultFound:
+            current_app.logger.info('Creating library from scratch: {}'
+                                    .format(library))
+            permission = Permissions(owner=True)
+            lib = Library(
+                name=library['name'],
+                description=library['description'],
+            )
+            lib.add_bibcodes(library['documents'])
+
+            lib.permissions.append(permission)
+            user.permissions.append(permission)
+
+            db.session.add_all([lib, permission, user])
+
+            bibcode_added = len(lib.get_bibcodes())
+            action = 'created'
+
+        db.session.commit()
+
+        return {
+            'library_id': BaseView.helper_uuid_to_slug(lib.id),
+            'name': lib.name,
+            'description': lib.description,
+            'num_added': bibcode_added,
+            'action': action
+        }
+
+    # Methods
+    def get(self):
+        """
+        HTTP GET request that
+
+        :return:
+
+        Header:
+        Must contain the API forwarded user ID of the user accessing the end
+        point
+
+        Post body:
+        ----------
+        No post content accepted.
+
+
+        Return data:
+        -----------
+
+        Permissions:
+        -----------
+        The following type of user can read a library:
+          - user scope (authenticated via the API)
+        """
+        # Check that they pass a user id
+        try:
+            user = self.helper_get_user_id()
+        except KeyError:
+            return err(MISSING_USERNAME_ERROR)
+
+        service_uid = self.helper_absolute_uid_to_service_uid(absolute_uid=user)
+
+        url = '{classic_service}/{user_id}'.format(
+            classic_service=current_app.config['BIBLIB_CLASSIC_SERVICE_URL'],
+            user_id=user
+        )
+        current_app.logger.info('Collecting libraries for user {} from {}'
+                                .format(user, url))
+        response = client().get(url)
+
+        if response.status_code != 200:
+            return response.json(), response.status_code
+
+        resp = []
+        for library in response.json()['libraries']:
+            resp.append(self.upsert_library(service_uid=service_uid, library=library))
+
+        return resp, 200

--- a/biblib/views/http_errors.py
+++ b/biblib/views/http_errors.py
@@ -46,3 +46,7 @@ SOLR_RESPONSE_MISMATCH_ERROR = dict(
          'request.',
     number=404
 )
+NO_CLASSIC_ACCOUNT = dict(
+    body='This user has not setup an ADS Classic account',
+    number=400
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ fake-factory
 factory_boy
 consulate==0.6.0
 flask-consulate==0.1.2
+httmock==1.2.3


### PR DESCRIPTION
Added an import end point for the classic service. This is a simple
get end point that starts the pulling and compiling of libraries from
ADS classic to BBB, assuming that the user has setup an ADS account
in their settings. If they have not, this will not do anything.

The process is idempotent. There are tests for two different scenarios,
that should cover most of the use cases.