### PR TITLE
Allow readonly access for a special token (i.e., myADS token)

### DIFF
--- a/biblib/views/library_view.py
+++ b/biblib/views/library_view.py
@@ -53,7 +53,7 @@ class LibraryView(BaseView):
             )
             current_app.logger.info('Obtaining email of user: {0} [API UID]'
                                     .format(owner.absolute_uid))
-            
+
             response = client().get(
                 service
             )
@@ -443,8 +443,9 @@ class LibraryView(BaseView):
             )
             return err(MISSING_LIBRARY_ERROR)
 
-        # Skip anymore logic if the library is public
-        if library.public:
+        # Skip anymore logic if the library is public or the exception token is present
+        special_token = current_app.config.get('READONLY_ALL_LIBRARIES_TOKEN')
+        if library.public or (special_token and request.headers.get('Authorization', '').endswith(special_token)):
             current_app.logger.info('Library: {0} is public'
                                     .format(library.id))
             return response, 200

--- a/config.py
+++ b/config.py
@@ -37,3 +37,6 @@ MAIL_DEFAULT_SENDER = 'no-reply@adslabs.org'
 # when set, the service will use it instead of the user's token
 # (for requests where it makes sense - not all)
 SERVICE_TOKEN = None
+
+# myADS token to allow general notifications that contain docs(library/<id>)
+READONLY_ALL_LIBRARIES_TOKEN = None


### PR DESCRIPTION
- Allow myADS pipeline to deal with general notifications that contain the docs(library/<id>) operator for private libraries