### PR TITLE
Return raw library

### DIFF
--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -238,6 +238,43 @@ class TestWebservices(TestCaseDatabase):
         self.assertIn('documents', response.json)
         self.assertIn('solr', response.json)
 
+    def test_get_raw_data_for_documents(self):
+        """
+        Test the /libraries/<> route to check that solr data is returned by
+        the service
+
+        :return: no return
+        """
+
+        # Stub data
+        stub_user = UserShop()
+        stub_library = LibraryShop(want_bibcode=True)
+
+        # Make the library
+        url = url_for('userview')
+        response = self.client.post(
+            url,
+            data=stub_library.user_view_post_data_json,
+            headers=stub_user.headers
+        )
+        self.assertEqual(response.status_code, 200)
+        library_id = response.json['id']
+        for key in ['name', 'id', 'bibcode', 'description']:
+            self.assertIn(key, response.json)
+
+        # Check the library exists in the database
+        url = url_for('libraryview', library=library_id)
+        with MockSolrBigqueryService() as BQ, \
+                MockEmailService(stub_user, end_type='uid') as ES:
+            response = self.client.get(
+                url,
+                headers=stub_user.headers, query_string={"raw":"true"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('documents', response.json)
+        self.assertIn('solr', response.json)
+        self.assertEqual(response.json['solr'], 'Only the raw library was requested.')
+
     def test_pagination_when_someone_passes_strings(self):
         """
         Ensure that even if someone passes strings as start/rows, that it does

--- a/biblib/tests/unit_tests/test_webservices.py
+++ b/biblib/tests/unit_tests/test_webservices.py
@@ -14,7 +14,6 @@ from biblib.views.http_errors import DUPLICATE_LIBRARY_NAME_ERROR, \
 from biblib.tests.stubdata.stub_data import LibraryShop, UserShop, fake_biblist
 from biblib.tests.base import MockEmailService, MockSolrBigqueryService,\
     TestCaseDatabase, MockEndPoint, MockClassicService, MockSolrQueryService
-from biblib.views import DocumentView
 from biblib.utils import get_item
 
 

--- a/biblib/utils.py
+++ b/biblib/utils.py
@@ -5,6 +5,7 @@ project, and so do not belong to anything specific.
 """
 
 from collections import Counter
+import json
 
 def get_GET_params(request, types={}):
     """
@@ -101,3 +102,10 @@ def get_item(list_of_dictionaries, key):
     return next(
         item[key]for item in list_of_dictionaries if key in item.keys()
     )
+
+def check_boolean(value):
+    if str(value).lower() not in ['true', 'false']: 
+        raise ValueError
+    else:
+        #safe way to convert string to boolean
+        return json.loads(value.lower())

--- a/biblib/views/http_errors.py
+++ b/biblib/views/http_errors.py
@@ -53,7 +53,7 @@ API_MISSING_USER_UID = dict(
 )
 SOLR_RESPONSE_MISMATCH_ERROR = dict(
     body='Solr response does not contain the same number of bibcodes as the '
-         'request.',
+         'request, or only the raw library was requested.',
     number=404
 )
 NO_CLASSIC_ACCOUNT = dict(

--- a/biblib/views/http_errors.py
+++ b/biblib/views/http_errors.py
@@ -52,8 +52,7 @@ API_MISSING_USER_UID = dict(
     number=404
 )
 SOLR_RESPONSE_MISMATCH_ERROR = dict(
-    body='Solr response does not contain the same number of bibcodes as the '
-         'request, or only the raw library was requested.',
+    body='Solr response does not contain the same number of bibcodes as the request.',
     number=404
 )
 NO_CLASSIC_ACCOUNT = dict(

--- a/biblib/views/library_view.py
+++ b/biblib/views/library_view.py
@@ -369,8 +369,8 @@ class LibraryView(BaseView):
                     documents = documents[start:start+rows]
             
             else:
-                solr = SOLR_RESPONSE_MISMATCH_ERROR['body']
-                current_app.logger.warning('User: {0} requested only raw library output'
+                solr = 'Only the raw library was requested.'
+                current_app.logger.info('User: {0} requested only raw library output'
                                             .format(user))
                 updates = {}
                 documents = library.get_bibcodes()

--- a/biblib/views/library_view.py
+++ b/biblib/views/library_view.py
@@ -297,7 +297,7 @@ class LibraryView(BaseView):
         except ValueError:
             start = 0
             rows = 20
-            raw_library = False
+            raw_library = bool(request.args.get('raw', False))
 
         sort = request.args.get('sort', 'date desc')
         fl = request.args.get('fl', 'bibcode')
@@ -367,6 +367,9 @@ class LibraryView(BaseView):
                     documents = documents[start:start+rows]
             
             else:
+                solr = SOLR_RESPONSE_MISMATCH_ERROR['body']
+                current_app.logger.warning('User: {0} requested only raw library output'
+                                            .format(user))
                 updates = {}
                 documents = library.get_bibcodes()
                 documents.sort()

--- a/biblib/views/library_view.py
+++ b/biblib/views/library_view.py
@@ -297,6 +297,8 @@ class LibraryView(BaseView):
         except ValueError:
             start = 0
             rows = 20
+            raw_library = False
+
         sort = request.args.get('sort', 'date desc')
         fl = request.args.get('fl', 'bibcode')
         current_app.logger.info('User gave pagination parameters:'

--- a/biblib/views/library_view.py
+++ b/biblib/views/library_view.py
@@ -2,7 +2,7 @@
 Library view
 """
 from biblib.views import USER_ID_KEYWORD
-from biblib.utils import err
+from biblib.utils import err, check_boolean
 from biblib.models import User, Library, Permissions
 from biblib.client import client
 from biblib.views.base_view import BaseView
@@ -292,12 +292,13 @@ class LibraryView(BaseView):
             )
             max_rows = int(max_rows)
             rows = min(int(request.args.get('rows', 20)), max_rows)
-            raw_library = bool(request.args.get('raw', False))
+            raw_library = check_boolean(request.args.get('raw', 'false'))
 
         except ValueError:
+            current_app.logger.debug("Raised value error")
             start = 0
             rows = 20
-            raw_library = bool(request.args.get('raw', False))
+            raw_library = False
 
         sort = request.args.get('sort', 'date desc')
         fl = request.args.get('fl', 'bibcode')
@@ -305,7 +306,8 @@ class LibraryView(BaseView):
                                 'start: {}, '
                                 'rows: {}, '
                                 'sort: "{}", '
-                                'fl: "{}"'.format(start, rows, sort, fl))
+                                'fl: "{}", '
+                                'raw: "{}"'.format(start, rows, sort, fl, raw_library))
 
         try:
             library = self.helper_slug_to_uuid(library)


### PR DESCRIPTION
Gives users the option to return raw bibcodes from a library instead of the bibcodes returned from `bigquery`